### PR TITLE
feat: add `ignore_extra_title` to BaseSettings and refactor usage

### DIFF
--- a/Online/ModInit.cs
+++ b/Online/ModInit.cs
@@ -54,6 +54,7 @@ namespace Online
                 version = CoreInit.conf.online.version,
                 btn_priority_forced = CoreInit.conf.online.btn_priority_forced,
                 showquality = true,
+                showExtraTitle = true,
                 limit_map = new List<WafLimitRootMap>
                 {
                     new("^/lite/", new WafLimitMap { limit = 10, second = 1 }),

--- a/Online/ModuleConf.cs
+++ b/Online/ModuleConf.cs
@@ -17,6 +17,8 @@ namespace Online
 
         public bool showquality { get; set; }
 
+        public bool showExtraTitle { get; set; }
+
         public string apn { get; set; }
 
         public Dictionary<string, string> appReplace { get; set; }

--- a/Online/OnlineApi.cs
+++ b/Online/OnlineApi.cs
@@ -672,6 +672,7 @@ namespace Online
                     return;
 
                 string displayname = init.displayname ?? name ?? init.plugin;
+                string extraTitle = ModInit.conf.showExtraTitle && !string.IsNullOrEmpty(arg_title) ? arg_title : string.Empty;
 
                 if (string.IsNullOrEmpty(url))
                 {
@@ -687,7 +688,7 @@ namespace Online
                         url += (url.Contains("?") ? "&" : "?") + "clarification=1";
                 }
 
-                online.Add(($"{displayname}{arg_title}", url, (plugin ?? init.plugin ?? name).ToLower(), init.displayindex > 0 ? init.displayindex : online.Count));
+                online.Add(($"{displayname}{extraTitle}", url, (plugin ?? init.plugin ?? name).ToLower(), init.displayindex > 0 ? init.displayindex : online.Count));
             }
             #endregion
 


### PR DESCRIPTION
Added ignore_extra_title property to BaseSettings for controlling extra title display. Updated OnlineApi.cs to respect this setting when building display names.