### PR TITLE
refactor: Samsung widget build to use per-host cache dir

### DIFF
--- a/Modules/LampaWeb/Controllers/ApiController.cs
+++ b/Modules/LampaWeb/Controllers/ApiController.cs
@@ -314,23 +314,28 @@ namespace LampaWeb.Controllers
         [Route("samsung.wgt")]
         public ActionResult SamsWgt(string overwritehost)
         {
-            string wgt = $"data/{CrypTo.md5(overwritehost ?? host + "v3")}.wgt";
+            string cache = $"cache/widgets/samsung/{CrypTo.md5(overwritehost ?? host + "v3")}";
+            string wgt = $"{cache}.wgt";
+
             if (IO.File.Exists(wgt))
                 return File(IO.File.OpenRead(wgt), "application/octet-stream");
 
             var widgetDirectory = $"{ModInit.modpath}/widgets/samsung";
+            var publishDirectory = $"{cache}/publish";
+
+            IO.Directory.CreateDirectory(publishDirectory);
 
             string index = IO.File.ReadAllText($"{widgetDirectory}/index.html");
-            IO.File.WriteAllText($"{widgetDirectory}/publish/index.html", index.Replace("{localhost}", overwritehost ?? host));
+            IO.File.WriteAllText($"{publishDirectory}/index.html", index.Replace("{localhost}", overwritehost ?? host));
 
             string loader = IO.File.ReadAllText($"{widgetDirectory}/loader.js");
-            IO.File.WriteAllText($"{widgetDirectory}/publish/loader.js", loader.Replace("{localhost}", overwritehost ?? host));
+            IO.File.WriteAllText($"{publishDirectory}/loader.js", loader.Replace("{localhost}", overwritehost ?? host));
             string app = IO.File.ReadAllText($"{widgetDirectory}/app.js");
-            IO.File.WriteAllText($"{widgetDirectory}/publish/app.js", app.Replace("{localhost}", overwritehost ?? host));
+            IO.File.WriteAllText($"{publishDirectory}/app.js", app.Replace("{localhost}", overwritehost ?? host));
 
-            IO.File.Copy($"{widgetDirectory}/icon.png", $"{widgetDirectory}/publish/icon.png", overwrite: true);
-            IO.File.Copy($"{widgetDirectory}/logo_appname_fg.png", $"{widgetDirectory}/publish/logo_appname_fg.png", overwrite: true);
-            IO.File.Copy($"{widgetDirectory}/config.xml", $"{widgetDirectory}/publish/config.xml", overwrite: true);
+            IO.File.Copy($"{widgetDirectory}/icon.png", $"{publishDirectory}/icon.png", overwrite: true);
+            IO.File.Copy($"{widgetDirectory}/logo_appname_fg.png", $"{publishDirectory}/logo_appname_fg.png", overwrite: true);
+            IO.File.Copy($"{widgetDirectory}/config.xml", $"{publishDirectory}/config.xml", overwrite: true);
 
             string gethash(string file)
             {
@@ -340,12 +345,12 @@ namespace LampaWeb.Controllers
                 }
             }
 
-            string indexhashsha512 = gethash($"{widgetDirectory}/publish/index.html");
-            string loaderhashsha512 = gethash($"{widgetDirectory}/publish/loader.js");
-            string apphashsha512 = gethash($"{widgetDirectory}/publish/app.js");
-            string confighashsha512 = gethash($"{widgetDirectory}/publish/config.xml");
-            string iconhashsha512 = gethash($"{widgetDirectory}/publish/icon.png");
-            string logohashsha512 = gethash($"{widgetDirectory}/publish/logo_appname_fg.png");
+            string indexhashsha512 = gethash($"{publishDirectory}/index.html");
+            string loaderhashsha512 = gethash($"{publishDirectory}/loader.js");
+            string apphashsha512 = gethash($"{publishDirectory}/app.js");
+            string confighashsha512 = gethash($"{publishDirectory}/config.xml");
+            string iconhashsha512 = gethash($"{publishDirectory}/icon.png");
+            string logohashsha512 = gethash($"{publishDirectory}/logo_appname_fg.png");
 
             string author_sigxml = IO.File.ReadAllText($"{widgetDirectory}/author-signature.xml");
             author_sigxml = author_sigxml
@@ -356,15 +361,23 @@ namespace LampaWeb.Controllers
                 .Replace("confighashsha512", confighashsha512)
                 .Replace("indexhashsha512", indexhashsha512);
 
-            IO.File.WriteAllText($"{widgetDirectory}/publish/author-signature.xml", author_sigxml);
+            IO.File.WriteAllText($"{publishDirectory}/author-signature.xml", author_sigxml);
 
-            string authorsignaturehashsha512 = gethash($"{widgetDirectory}/publish/author-signature.xml");
+            string authorsignaturehashsha512 = gethash($"{publishDirectory}/author-signature.xml");
             string sigxml1 = IO.File.ReadAllText($"{widgetDirectory}/signature1.xml");
-            sigxml1 = sigxml1.Replace("loaderhashsha512", loaderhashsha512).Replace("apphashsha512", apphashsha512)
-                             .Replace("confighashsha512", confighashsha512).Replace("authorsignaturehashsha512", authorsignaturehashsha512)
-                             .Replace("iconhashsha512", iconhashsha512).Replace("logohashsha512", logohashsha512).Replace("indexhashsha512", indexhashsha512);
-            IO.File.WriteAllText($"{widgetDirectory}/publish/signature1.xml", sigxml1);
-            ZipFile.CreateFromDirectory($"{widgetDirectory}/publish/", wgt);
+            sigxml1 = sigxml1
+                .Replace("loaderhashsha512", loaderhashsha512)
+                .Replace("apphashsha512", apphashsha512)
+                .Replace("confighashsha512", confighashsha512)
+                .Replace("authorsignaturehashsha512", authorsignaturehashsha512)
+                .Replace("iconhashsha512", iconhashsha512)
+                .Replace("logohashsha512", logohashsha512)
+                .Replace("indexhashsha512", indexhashsha512);
+
+            IO.File.WriteAllText($"{publishDirectory}/signature1.xml", sigxml1);
+            ZipFile.CreateFromDirectory(publishDirectory, wgt);
+
+            IO.Directory.Delete(publishDirectory, true);
 
             return File(IO.File.OpenRead(wgt), "application/octet-stream");
         }


### PR DESCRIPTION
Refactored the Samsung widget generation to use a unique cache directory per host hash. All build artifacts are now isolated in cache/widgets/samsung/{hash}/publish, preventing conflicts and improving caching. Temporary publish directories are cleaned up after packaging.