### PR TITLE
fead: add recursive module manifests support

### DIFF
--- a/Core/README.md
+++ b/Core/README.md
@@ -28,7 +28,7 @@
 1. Каталоги обрабатываются в порядке **`mods`**, затем **`module`**.
 2. Из подкаталога **`references/`** подгружаются готовые **`.dll`** как части приложения MVC.
 3. Собственные **`.dll`** в корне `mods/` / `module/` подключаются как сборки модулей.
-4. Папки с **`manifest.json`**: при необходимости компиляция **Roslyn** ([`CSharpEval.Compilation`](../Shared/Services/CSharpEval.cs)); учитываются **`BaseModule.SkipModules`**, **`LoadModules`**, флаг **`enable`** в манифесте.
+4. Папки с **`manifest.json`** (на любой вложенности): при необходимости компиляция **Roslyn** ([`CSharpEval.Compilation`](../Shared/Services/CSharpEval.cs)); учитываются **`BaseModule.SkipModules`**, **`LoadModules`**, флаг **`enable`** в манифесте. Для `LoadModules` поддержаны: точное имя модуля (`"KinoUkr"`), имя группы/папки верхнего уровня (`"OnlineUKR"` или имя репозитория вроде `"lampac-ukraine"`), маски (`"LME.*"`), а также `"*"` / `".*"` для загрузки всего.
 5. После сборки для каждого модуля вызывается **`IModuleConfigure.Configure`**.
 
 В **`Configure`** после старта приложения для каждого модуля вызывается **`IModuleLoaded.Loaded`**. Для модулей с **`dynamic: true`** в манифесте включается пересборка при изменении **`.cs`** (см. `WatchersDynamicModule` в `Startup.cs`).

--- a/Core/Startup.cs
+++ b/Core/Startup.cs
@@ -283,34 +283,7 @@ namespace Core
                     #endregion
 
                     #region compilation
-                    List<string> compilationFolders = new();
-
-                    foreach (string folderMod in Directory.GetDirectories(Path.Combine(AppContext.BaseDirectory, modfolder)))
-                    {
-                        string folderName = Path.GetFileName(folderMod);
-                        if (skipCompilationFolders.Contains(folderName))
-                        {
-                            Console.WriteLine($"skip compilation folder {modfolder}: {folderName}");
-                            continue;
-                        }
-
-                        if (File.Exists(Path.Combine(folderMod, "manifest.json")))
-                            compilationFolders.Add(folderMod);
-                        else
-                        {
-                            foreach (string recurseMod in Directory.GetDirectories(folderMod))
-                            {
-                                folderName = Path.GetFileName(recurseMod);
-                                if (skipCompilationFolders.Contains(folderName))
-                                {
-                                    Console.WriteLine($"skip compilation folder {modfolder}: {folderName}");
-                                    continue;
-                                }
-
-                                compilationFolders.Add(recurseMod);
-                            }
-                        }
-                    }
+                    List<string> compilationFolders = CollectCompilationFolders(modfolder, skipCompilationFolders);
 
                     foreach (string folderMod in compilationFolders)
                     {
@@ -318,7 +291,8 @@ namespace Core
                             continue;
 
                         string folderName = Path.GetFileName(folderMod);
-                        if (mods.LoadModules[0] != ".*" && !mods.LoadModules.Contains(folderName))
+                        string parentFolderName = Path.GetFileName(Directory.GetParent(folderMod)?.FullName);
+                        if (!IsLoadModuleAllowed(mods.LoadModules, folderName, parentFolderName))
                             continue;
 
                         string manifest = Path.Combine(folderMod, "manifest.json");
@@ -830,5 +804,82 @@ namespace Core
             }
         }
         #endregion
+
+        static List<string> CollectCompilationFolders(string modfolder, HashSet<string> skipCompilationFolders)
+        {
+            var result = new List<string>();
+            string rootPath = Path.Combine(AppContext.BaseDirectory, modfolder);
+
+            if (!Directory.Exists(rootPath))
+                return result;
+
+            var pending = new Stack<string>(Directory.GetDirectories(rootPath));
+
+            while (pending.Count > 0)
+            {
+                string folderPath = pending.Pop();
+                string folderName = Path.GetFileName(folderPath);
+
+                if (skipCompilationFolders.Contains(folderName))
+                {
+                    Console.WriteLine($"skip compilation folder {modfolder}: {folderName}");
+                    continue;
+                }
+
+                if (File.Exists(Path.Combine(folderPath, "manifest.json")))
+                {
+                    result.Add(folderPath);
+                    continue;
+                }
+
+                foreach (string childPath in Directory.GetDirectories(folderPath))
+                    pending.Push(childPath);
+            }
+
+            return result;
+        }
+
+        static bool IsLoadModuleAllowed(string[] loadModules, string moduleName, string parentFolderName)
+        {
+            if (loadModules == null || loadModules.Length == 0)
+                return false;
+
+            foreach (string rawPattern in loadModules)
+            {
+                string pattern = rawPattern?.Trim();
+                if (string.IsNullOrWhiteSpace(pattern))
+                    continue;
+
+                if (pattern == ".*" || pattern == "*")
+                    return true;
+
+                if (pattern.Equals(moduleName, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                if (!string.IsNullOrEmpty(parentFolderName) && pattern.Equals(parentFolderName, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                string dottedName = string.IsNullOrEmpty(parentFolderName)
+                    ? moduleName
+                    : $"{parentFolderName}.{moduleName}";
+
+                if (IsWildcardMatch(pattern, moduleName) || IsWildcardMatch(pattern, dottedName))
+                    return true;
+            }
+
+            return false;
+        }
+
+        static bool IsWildcardMatch(string pattern, string value)
+        {
+            if (string.IsNullOrEmpty(pattern) || string.IsNullOrEmpty(value))
+                return false;
+
+            if (pattern.IndexOfAny(new[] { '*', '?' }) == -1)
+                return false;
+
+            string regexPattern = $"^{Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", ".")}$";
+            return Regex.IsMatch(value, regexPattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -333,7 +333,8 @@ RUNTIME_ID=linux-arm64 ./build.sh
   "BaseModule": {
     "ValidateRequest": true,    // валидация входящих запросов
     "BlockedBots": true,        // блокировка ботов
-    "SkipModules": []           // список отключённых модулей
+    "SkipModules": [],          // список отключённых модулей
+    "LoadModules": [".*"]       // whitelist: имя модуля, группа (OnlineUKR), маска (LME.*)
   },
 
   // Кеш

--- a/Shared/Services/Module/ModuleRepository.cs
+++ b/Shared/Services/Module/ModuleRepository.cs
@@ -74,7 +74,7 @@ namespace Shared.Services
                             continue;
                         }
 
-                        bool missingModule = repository.Folders.Any(folder => !Directory.Exists(Path.Combine(Environment.CurrentDirectory, RepositoryDirectory, folder.ModuleName)));
+                        bool missingModule = repository.Folders.Any(folder => !Directory.Exists(GetRepositoryModulePath(repository, folder)));
                         string commitSha = GetLatestCommitSha(repository, state, ref stateChanged);
                         if (string.IsNullOrEmpty(commitSha))
                         {
@@ -916,7 +916,21 @@ namespace Shared.Services
                         continue;
                     }
 
-                    string destinationPath = Path.Combine(Environment.CurrentDirectory, RepositoryDirectory, repository.Owner, folder.ModuleName);
+                    string destinationPath = GetRepositoryModulePath(repository, folder);
+                    string legacyPath = Path.Combine(Environment.CurrentDirectory, RepositoryDirectory, repository.Owner, folder.ModuleName);
+
+                    if (!string.Equals(legacyPath, destinationPath, StringComparison.OrdinalIgnoreCase) && Directory.Exists(legacyPath))
+                    {
+                        try
+                        {
+                            Directory.Delete(legacyPath, true);
+                            Log($"Removed legacy module path '{legacyPath}'");
+                        }
+                        catch (Exception ex)
+                        {
+                            LogError(ex, $"Failed to remove legacy path '{legacyPath}'");
+                        }
+                    }
 
                     string existingManifestJson = null;
                     string existingManifestPath = Path.Combine(destinationPath, "manifest.json");
@@ -976,6 +990,21 @@ namespace Shared.Services
                 try { if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true); } catch { }
                 Log($"Download and extract finished for {repository.Owner}/{repository.Name}");
             }
+        }
+
+        private static string GetRepositoryBasePath(RepositoryEntry repository)
+        {
+            return Path.Combine(
+                Environment.CurrentDirectory,
+                RepositoryDirectory,
+                repository.Owner,
+                repository.Name
+            );
+        }
+
+        private static string GetRepositoryModulePath(RepositoryEntry repository, RepositoryFolder folder)
+        {
+            return Path.Combine(GetRepositoryBasePath(repository), folder.ModuleName);
         }
 
         private static string MergeManifests(string existingJson, string newJson)


### PR DESCRIPTION
### Motivation

- Allow module `manifest.json` to be discovered at any nesting level so nested module layouts are supported.
- Provide flexible whitelisting for module loading via `LoadModules` including exact names, parent-folder/group names, and wildcard patterns.
- Normalize repository extraction paths and remove legacy module locations to avoid duplicated/incorrect module directories.

### Description

- Replace ad-hoc folder traversal in `Startup.cs` with `CollectCompilationFolders` to recursively find folders that contain `manifest.json` and skip configured directories via `skipCompilationFolders`.
- Add `IsLoadModuleAllowed` and `IsWildcardMatch` to support `LoadModules` patterns: exact module name, parent folder/group name, dotted `parent.module` forms, wildcards (e.g. `LME.*`) and global patterns `"*"`/`".*"`.
- Update module discovery to check both module name and parent folder when deciding whether to compile and load a module using the new helpers in `Startup.cs`.
- In `Shared/Services/Module/ModuleRepository.cs` introduce `GetRepositoryBasePath` and `GetRepositoryModulePath`, change destination paths to the new layout, and remove legacy module path if present during extraction to prevent stale directories.
- Update documentation in `Core/README.md` and `README.md` to describe recursive manifest lookup and the new `BaseModule.LoadModules` configuration with example patterns and default `[".*"]` behavior, plus minor whitespace fixes.