### PR TITLE
fix: improve Zetflix serial fallback and parsing

### DIFF
--- a/Modules/OnlineRUS/Zetflix/Controller.cs
+++ b/Modules/OnlineRUS/Zetflix/Controller.cs
@@ -167,6 +167,37 @@ namespace Zetflix
 
             if (html == null)
             {
+                if (serial == 1)
+                {
+                    if (s == -1 && id > 0)
+                    {
+                        int seasonCount = await GetTmdbAvailableSeasonCount(id);
+
+                        var seedSerial = BuildSyntheticSerialEmbed(1, "Озвучка");
+                        if (seasonCount > 0 && seedSerial?.pl?.Count > 0 && !seedSerial.movie)
+                        {
+                            if (origsource)
+                                return Json(seedSerial);
+
+                            return ContentTpl(oninvk.Tpl(seedSerial, seasonCount, id, kinopoisk_id, title, original_title, t, s, vast: init.vast));
+                        }
+                    }
+
+                    if (rs > 0)
+                    {
+                        var fallbackSerial = await CaptureBestSerialFallback(ztfhost, id, kinopoisk_id, rs, retry: true);
+                        if (fallbackSerial?.pl?.Count > 0 && !fallbackSerial.movie)
+                        {
+                            if (origsource)
+                                return Json(fallbackSerial);
+
+                            return ContentTpl(oninvk.Tpl(fallbackSerial, 1, id, kinopoisk_id, title, original_title, t, s, vast: init.vast));
+                        }
+                    }
+
+                    return OnError();
+                }
+
                 var liveMovie = await CaptureLiveMovie(ztfhost, kinopoisk_id, rs, title, original_title);
                 if (!liveMovie.IsEmpty)
                 {
@@ -184,7 +215,27 @@ namespace Zetflix
 
             var content = oninvk.Embed(html);
 
-            if ((content?.movie == true && NeedLiveMovieFallback(content)) || content?.pl == null)
+            if (serial == 1 && s == -1 && NeedSyntheticSeasonList(content, id))
+            {
+                int seasonCount = await GetTmdbAvailableSeasonCount(id);
+                var seedSerial = BuildSyntheticSerialEmbed(1, "Озвучка");
+                if (seasonCount > 0 && seedSerial?.pl?.Count > 0 && !seedSerial.movie)
+                {
+                    if (origsource)
+                        return Json(seedSerial);
+
+                    return ContentTpl(oninvk.Tpl(seedSerial, seasonCount, id, kinopoisk_id, title, original_title, t, s, vast: init.vast));
+                }
+            }
+
+            if (serial == 1 && NeedLiveSerialFallback(content))
+            {
+                var fallbackSerial = await CaptureBestSerialFallback(ztfhost, id, kinopoisk_id, rs, retry: true);
+                if (fallbackSerial?.pl?.Count > 0 && !fallbackSerial.movie)
+                    content = fallbackSerial;
+            }
+
+            if (serial != 1 && ((content?.movie == true && NeedLiveMovieFallback(content)) || content?.pl == null))
             {
                 var liveMovie = await CaptureLiveMovie(ztfhost, kinopoisk_id, rs, title, original_title);
                 if (!liveMovie.IsEmpty)
@@ -262,6 +313,441 @@ namespace Zetflix
             return detected > 0 ? detected : 1;
         }
 
+        bool NeedSyntheticSeasonList(EmbedModel content, long id)
+        {
+            if (id <= 0)
+                return false;
+
+            if (content?.pl == null || content.pl.Count == 0)
+                return true;
+
+            if (content.movie)
+                return true;
+
+            return !content.pl.Any(p => p.folder != null && p.folder.Length > 0);
+        }
+
+        bool NeedLiveSerialFallback(EmbedModel content)
+        {
+            if (content?.pl == null || content.pl.Count == 0)
+                return true;
+
+            if (content.movie)
+                return true;
+
+            return !content.pl.Any(p => p.folder != null && p.folder.Length > 0);
+        }
+
+        async ValueTask<EmbedModel> CaptureLiveSerialEmbed(string ztfhost, long kinopoisk_id, int season)
+        {
+            string memKey = $"zetflix:live_serial_tpl:v1:{kinopoisk_id}:{season}:{proxyManager?.CurrentProxyIp}";
+            if (!hybridCache.TryGetValue(memKey, out EmbedModel cache))
+            {
+                cache = await CaptureLiveSerialEmbedInternal(ztfhost, kinopoisk_id, season);
+                if (cache?.pl?.Count > 0 && !cache.movie)
+                    hybridCache.Set(memKey, cache, cacheTime(300));
+            }
+
+            return cache;
+        }
+
+        async ValueTask<EmbedModel> CaptureSyntheticSerialEmbed(string ztfhost, long id, long kinopoisk_id, int season)
+        {
+            if (id <= 0 || season <= 0)
+                return default;
+
+            string memKey = $"zetflix:synthetic_serial:v1:{id}:{kinopoisk_id}:{season}:{proxyManager?.CurrentProxyIp}";
+            if (!hybridCache.TryGetValue(memKey, out EmbedModel cache))
+            {
+                cache = await CaptureSyntheticSerialEmbedInternal(ztfhost, id, kinopoisk_id, season);
+                if (cache?.pl?.Count > 0 && !cache.movie)
+                    hybridCache.Set(memKey, cache, cacheTime(300));
+            }
+
+            return cache;
+        }
+
+        async ValueTask<EmbedModel> CaptureBestSerialFallback(string ztfhost, long id, long kinopoisk_id, int season, bool retry)
+        {
+            async ValueTask<EmbedModel> attempt()
+            {
+                var liveSerial = await CaptureLiveSerialEmbed(ztfhost, kinopoisk_id, season);
+                if (liveSerial?.pl?.Count > 0 && !liveSerial.movie)
+                    return liveSerial;
+
+                if (id > 0)
+                {
+                    var syntheticSerial = await CaptureSyntheticSerialEmbed(ztfhost, id, kinopoisk_id, season);
+                    if (syntheticSerial?.pl?.Count > 0 && !syntheticSerial.movie)
+                        return syntheticSerial;
+                }
+
+                return default;
+            }
+
+            var content = await attempt();
+            if (content?.pl?.Count > 0 && !content.movie)
+                return content;
+
+            if (!retry)
+                return default;
+
+            await Task.Delay(250);
+            return await attempt();
+        }
+
+        async ValueTask<EmbedModel> CaptureSyntheticSerialEmbedInternal(string ztfhost, long id, long kinopoisk_id, int season)
+        {
+            if (string.IsNullOrWhiteSpace(ztfhost) || kinopoisk_id == 0 || id <= 0 || season <= 0)
+                return default;
+
+            string workingVoice = await DetectSyntheticSerialVoice(ztfhost, kinopoisk_id, season);
+            if (string.IsNullOrWhiteSpace(workingVoice))
+                workingVoice = "Озвучка";
+
+            int episodeCount = await GetTmdbSeasonEpisodeCount(id, season);
+            if (episodeCount <= 0)
+                return default;
+
+            return BuildSyntheticSerialEmbed(episodeCount, workingVoice);
+        }
+
+        async ValueTask<string> DetectSyntheticSerialVoice(string ztfhost, long kinopoisk_id, int season)
+        {
+            foreach (string voice in new[] { "Озвучка", "По умолчанию", "Дубляж" })
+            {
+                var probe = await CaptureLiveSerialEpisodeInternal(ztfhost, kinopoisk_id, season, voice, 1);
+                if (probe.qualitys?.Count > 0)
+                    return voice == "По умолчанию" ? "Озвучка" : voice;
+            }
+
+            return default;
+        }
+
+        async ValueTask<int> GetTmdbSeasonEpisodeCount(long id, int season)
+        {
+            if (id <= 0 || season <= 0)
+                return 0;
+
+            try
+            {
+                string themoviedb = await Http.Get($"https://api.themoviedb.org/3/tv/{id}/season/{season}?api_key=4ef0d7355d9ffb5151e987764708ce96&language=ru-RU", timeoutSeconds: 10, statusCodeOK: false);
+                if (string.IsNullOrWhiteSpace(themoviedb))
+                    return 0;
+
+                var root = JsonNode.Parse(themoviedb) as JsonObject;
+                var episodes = root?["episodes"] as JsonArray;
+                return episodes?.Count ?? 0;
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        async ValueTask<int> GetTmdbAvailableSeasonCount(long id)
+        {
+            if (id <= 0)
+                return 1;
+
+            try
+            {
+                string themoviedb = await Http.Get($"https://api.themoviedb.org/3/tv/{id}?api_key=4ef0d7355d9ffb5151e987764708ce96&language=ru-RU", timeoutSeconds: 10, statusCodeOK: false);
+                if (string.IsNullOrWhiteSpace(themoviedb))
+                    return 1;
+
+                var root = JsonNode.Parse(themoviedb) as JsonObject;
+                var seasons = root?["seasons"] as JsonArray;
+                if (seasons == null || seasons.Count == 0)
+                    return Math.Max(root?["number_of_seasons"]?.GetValue<int>() ?? 1, 1);
+
+                int count = 0;
+                foreach (var item in seasons)
+                {
+                    if (item is not JsonObject season)
+                        continue;
+
+                    int seasonNumber = season["season_number"]?.GetValue<int>() ?? 0;
+                    int episodeCount = season["episode_count"]?.GetValue<int>() ?? 0;
+                    string airDate = season["air_date"]?.GetValue<string>();
+
+                    if (seasonNumber <= 0 || episodeCount <= 0)
+                        continue;
+
+                    if (!string.IsNullOrWhiteSpace(airDate))
+                        count++;
+                }
+
+                return count > 0 ? count : Math.Max(root?["number_of_seasons"]?.GetValue<int>() ?? 1, 1);
+            }
+            catch
+            {
+                return 1;
+            }
+        }
+
+        static EmbedModel BuildSyntheticSerialEmbed(int episodeCount, string voiceTitle)
+        {
+            if (episodeCount <= 0)
+                return default;
+
+            var episodes = new Folder[episodeCount];
+            for (int i = 1; i <= episodeCount; i++)
+            {
+                episodes[i - 1] = new Folder()
+                {
+                    comment = $"{i} серия",
+                    file = $"episode://{i}"
+                };
+            }
+
+            return new EmbedModel()
+            {
+                pl = new List<RootObject>()
+                {
+                    new RootObject()
+                    {
+                        title = string.IsNullOrWhiteSpace(voiceTitle) ? "Озвучка" : voiceTitle,
+                        folder = episodes
+                    }
+                },
+                movie = false,
+                quality = "1080p"
+            };
+        }
+
+        async ValueTask<EmbedModel> CaptureLiveSerialEmbedInternal(string ztfhost, long kinopoisk_id, int season)
+        {
+            if (string.IsNullOrWhiteSpace(ztfhost) || kinopoisk_id == 0 || season <= 0)
+                return default;
+
+            string source = $"/iplayer/videodb.php?kp={kinopoisk_id}&season={season}";
+            string playerId = Convert.ToBase64String(Encoding.UTF8.GetBytes(source));
+            string playerUri = $"{ztfhost}/iplayer/player.php?id={playerId}";
+
+            try
+            {
+                string playerHtml = await Http.Get(playerUri, headers: HeadersModel.Init(
+                    ("Referer", $"{ztfhost}/"),
+                    ("Origin", ztfhost)
+                ), timeoutSeconds: 15, statusCodeOK: false);
+
+                var direct = await TrySerialEmbedFromPlayerHtml(playerHtml, playerUri, ztfhost, season);
+                if (direct?.pl?.Count > 0 && !direct.movie)
+                    return direct;
+            }
+            catch { }
+
+            try
+            {
+                using var browser = new PlaywrightBrowser(init.priorityBrowser);
+                var page = await browser.NewPageAsync(init.plugin, new Dictionary<string, string>()
+                {
+                    ["Referer"] = "https://www.google.com/"
+                }, proxy: proxy_data, keepopen: init.browser_keepopen).ConfigureAwait(false);
+
+                if (page == null)
+                    return default;
+
+                await page.RouteAsync("**/*", async route =>
+                {
+                    try
+                    {
+                        string url = route.Request.Url.Split("?")[0];
+                        if (Regex.IsMatch(url, "\\.(woff2?|vtt|srt|css|svg|jpe?g|png|gif|webp|ico|m3u8|mp4|m4s|ts)$", RegexOptions.IgnoreCase))
+                        {
+                            await route.AbortAsync();
+                            return;
+                        }
+
+                        await route.ContinueAsync();
+                    }
+                    catch { }
+                });
+
+                try
+                {
+                    await page.GotoAsync(playerUri, new PageGotoOptions()
+                    {
+                        Timeout = 15_000,
+                        WaitUntil = WaitUntilState.DOMContentLoaded
+                    }).ConfigureAwait(false);
+                }
+                catch { }
+
+                for (int i = 0; i < 40; i++)
+                {
+                    try
+                    {
+                        string playerHtml = await page.ContentAsync().ConfigureAwait(false);
+                        var direct = await TrySerialEmbedFromPlayerHtml(playerHtml, playerUri, ztfhost, season);
+                        if (direct?.pl?.Count > 0 && !direct.movie)
+                        {
+                            proxyManager?.Success();
+                            return direct;
+                        }
+                    }
+                    catch { }
+
+                    try
+                    {
+                        foreach (var frame in page.Frames)
+                        {
+                            string frameHtml = await frame.ContentAsync().ConfigureAwait(false);
+                            var direct = BuildSerialEmbedFromHtml(frameHtml, season);
+                            if (direct?.pl?.Count > 0 && !direct.movie)
+                            {
+                                proxyManager?.Success();
+                                return direct;
+                            }
+                        }
+                    }
+                    catch { }
+
+                    await Task.Delay(250);
+                }
+            }
+            catch { }
+
+            proxyManager?.Refresh();
+            return default;
+        }
+
+        async ValueTask<EmbedModel> TrySerialEmbedFromPlayerHtml(string playerHtml, string playerUri, string ztfhost, int season)
+        {
+            var direct = BuildSerialEmbedFromHtml(playerHtml, season);
+            if (direct?.pl?.Count > 0 && !direct.movie)
+                return direct;
+
+            string iframeSrc = Regex.Match(playerHtml ?? string.Empty, "<iframe[^>]*?\\ssrc=\"([^\"]+)\"", RegexOptions.IgnoreCase).Groups[1].Value;
+            if (string.IsNullOrWhiteSpace(iframeSrc))
+                return default;
+
+            string iframeUri = iframeSrc.StartsWith("//") ? $"https:{iframeSrc}" :
+                               iframeSrc.StartsWith("/") ? $"{ztfhost}{iframeSrc}" :
+                               iframeSrc;
+
+            var iframeResult = await Http.BaseGet(iframeUri,
+                headers: HeadersModel.Init(
+                    ("Referer", playerUri),
+                    ("Origin", ztfhost),
+                    ("Sec-Fetch-Dest", "iframe"),
+                    ("Sec-Fetch-Mode", "navigate"),
+                    ("Sec-Fetch-Site", "cross-site")
+                ),
+                timeoutSeconds: 15,
+                statusCodeOK: false,
+                cookieContainer: new CookieContainer()
+            );
+
+            return BuildSerialEmbedFromHtml(iframeResult.content, season);
+        }
+
+        EmbedModel BuildSerialEmbedFromHtml(string html, int season)
+        {
+            if (string.IsNullOrWhiteSpace(html))
+                return default;
+
+            var oninvk = new ZetflixInvoke(null, null, init.hls, null, link => link);
+            var embed = oninvk.Embed(html);
+            if (embed?.pl?.Count > 0 && !embed.movie && embed.pl.Any(p => p.folder != null && p.folder.Length > 0))
+                return embed;
+
+            if (!TryParseObrutPlayerRoot(html, out JsonObject root))
+                return default;
+
+            return BuildSerialEmbedFromObrutRoot(root, season);
+        }
+
+        EmbedModel BuildSerialEmbedFromObrutRoot(JsonObject root, int season)
+        {
+            if (root?["file"] is not JsonArray seasons)
+                return default;
+
+            JsonObject seasonNode = FindObrutFolderByNumber(seasons, season);
+            if (seasonNode == null && seasons.Count == 1 && season == 1)
+                seasonNode = seasons[0] as JsonObject;
+
+            if (seasonNode == null || seasonNode["folder"] is not JsonArray episodes)
+                return default;
+
+            var voiceMap = new Dictionary<string, List<Folder>>(StringComparer.OrdinalIgnoreCase);
+            var voiceOrder = new List<string>();
+
+            void addVoice(string voiceTitle, string comment, string file)
+            {
+                if (string.IsNullOrWhiteSpace(voiceTitle) || string.IsNullOrWhiteSpace(comment) || string.IsNullOrWhiteSpace(file))
+                    return;
+
+                if (!voiceMap.TryGetValue(voiceTitle, out var folders))
+                {
+                    folders = new List<Folder>();
+                    voiceMap[voiceTitle] = folders;
+                    voiceOrder.Add(voiceTitle);
+                }
+
+                folders.Add(new Folder()
+                {
+                    comment = comment,
+                    file = file
+                });
+            }
+
+            foreach (var episodeItem in episodes)
+            {
+                if (episodeItem is not JsonObject episodeNode)
+                    continue;
+
+                string comment = NormalizeObrutEpisodeComment(episodeNode);
+                if (string.IsNullOrWhiteSpace(comment))
+                    continue;
+
+                if (episodeNode["folder"] is JsonArray voices && voices.Count > 0)
+                {
+                    int voiceIndex = 0;
+
+                    foreach (var voiceItem in voices)
+                    {
+                        if (voiceItem is not JsonObject voiceNode)
+                            continue;
+
+                        string file = voiceNode["file"]?.GetValue<string>();
+                        if (string.IsNullOrWhiteSpace(file))
+                            continue;
+
+                        voiceIndex++;
+                        string voiceTitle = NormalizeObrutSerialVoiceTitle(voiceNode["title"]?.GetValue<string>(), voiceIndex);
+                        addVoice(voiceTitle, comment, file);
+                    }
+                }
+                else
+                {
+                    string file = episodeNode["file"]?.GetValue<string>();
+                    addVoice("Озвучка", comment, file);
+                }
+            }
+
+            if (voiceOrder.Count == 0)
+                return default;
+
+            var result = new List<RootObject>(voiceOrder.Count);
+            foreach (string voiceTitle in voiceOrder)
+            {
+                result.Add(new RootObject()
+                {
+                    title = voiceTitle,
+                    folder = voiceMap[voiceTitle].ToArray()
+                });
+            }
+
+            return new EmbedModel()
+            {
+                pl = result,
+                movie = false,
+                quality = "1080p"
+            };
+        }
+
         bool NeedLiveMovieFallback(EmbedModel content)
         {
             if (content?.pl == null || content.pl.Count == 0)
@@ -277,6 +763,18 @@ namespace Zetflix
             }
 
             return false;
+        }
+
+        static string NormalizeObrutEpisodeComment(JsonObject episodeNode)
+        {
+            string title = Regex.Replace(episodeNode?["title"]?.GetValue<string>() ?? string.Empty, "\\s+", " ").Trim();
+            if (string.IsNullOrWhiteSpace(title))
+                return string.Empty;
+
+            if (Regex.IsMatch(title, "^\\d+"))
+                return title;
+
+            return TryExtractNodeNumber(title, out int number) ? $"{number} серия" : title;
         }
 
         async ValueTask<MovieTpl> CaptureLiveMovie(string ztfhost, long kinopoisk_id, int season, string title, string original_title)
@@ -464,7 +962,7 @@ namespace Zetflix
 
                 string iframeSrc = Regex.Match(playerHtml ?? string.Empty, "<iframe[^>]*?\\ssrc=\"([^\"]+)\"", RegexOptions.IgnoreCase).Groups[1].Value;
                 if (string.IsNullOrWhiteSpace(iframeSrc))
-                    return default;
+                    return await TryPlayerjsSerial(ztfhost, kinopoisk_id, season, voice, episode);
 
                 string iframeUri = iframeSrc.StartsWith("//") ? $"https:{iframeSrc}" :
                                    iframeSrc.StartsWith("/") ? $"{ztfhost}{iframeSrc}" :
@@ -473,7 +971,11 @@ namespace Zetflix
                 if (!iframeUri.Contains(".obrut.show/", StringComparison.OrdinalIgnoreCase))
                     return await TryPlayerjsSerial(ztfhost, kinopoisk_id, season, voice, episode);
 
-                return await TryObrutSerial(iframeUri, pageUri, ztfhost, season, episode, voice);
+                var obrutResult = await TryObrutSerial(iframeUri, pageUri, ztfhost, season, episode, voice);
+                if (obrutResult.qualitys?.Count > 0)
+                    return obrutResult;
+
+                return await TryPlayerjsSerial(ztfhost, kinopoisk_id, season, voice, episode);
             }
             catch
             {
@@ -485,16 +987,22 @@ namespace Zetflix
         {
             try
             {
-                string uri = $"{ztfhost}/iplayer/videodb.php?kp={kinopoisk_id}&season={season}";
-                var reqHeaders = HeadersModel.Init(
-                    ("dnt", "1"),
-                    ("pragma", "no-cache"),
-                    ("referer", "https://www.google.com/"),
-                    ("upgrade-insecure-requests", "1")
-                );
+                // Try to reuse the cached HTML from Index endpoint first
+                string html = hybridCache.TryGetValue($"zetfix:view:{kinopoisk_id}:{season}:{proxyManager?.CurrentProxyIp}", out string cachedHtml) ? cachedHtml : null;
 
-                string html = string.IsNullOrEmpty(PHPSESSID) ? null :
-                    await Http.Get(uri, proxy: proxy, cookie: $"PHPSESSID={PHPSESSID}", headers: reqHeaders);
+                if (string.IsNullOrWhiteSpace(html) || html.StartsWith("<script>(function") || !html.Contains("new Playerjs"))
+                {
+                    string uri = $"{ztfhost}/iplayer/videodb.php?kp={kinopoisk_id}&season={season}";
+                    var reqHeaders = HeadersModel.Init(
+                        ("dnt", "1"),
+                        ("pragma", "no-cache"),
+                        ("referer", "https://www.google.com/"),
+                        ("upgrade-insecure-requests", "1")
+                    );
+
+                    html = string.IsNullOrEmpty(PHPSESSID) ? null :
+                        await Http.Get(uri, proxy: proxy, cookie: $"PHPSESSID={PHPSESSID}", headers: reqHeaders);
+                }
 
                 if (string.IsNullOrWhiteSpace(html) || html.StartsWith("<script>(function") || !html.Contains("new Playerjs"))
                     return default;
@@ -533,12 +1041,39 @@ namespace Zetflix
                     }
                 }
 
+                if (embed.pl.Count > 0 && IsGenericVoiceLabel(normalizedVoice))
+                {
+                    var qualitys = ParsePlayerjsQualityMap(FindPlayerjsEpisodeFile(embed.pl[0].folder, episode));
+                    if (qualitys.Count > 0)
+                        return (qualitys, null);
+                }
+
                 return default;
             }
             catch
             {
                 return default;
             }
+        }
+
+        static string FindPlayerjsEpisodeFile(Folder[] episodes, int episode)
+        {
+            if (episodes == null || episodes.Length == 0 || episode <= 0)
+                return null;
+
+            foreach (var ep in episodes)
+            {
+                string epNum = Regex.Match(ep.comment ?? string.Empty, "^([0-9]+)").Groups[1].Value;
+                if (epNum == episode.ToString())
+                    return ep.file;
+            }
+
+            return null;
+        }
+
+        static bool IsGenericVoiceLabel(string text)
+        {
+            return string.IsNullOrWhiteSpace(text) || text is "озвучка" or "по умолчанию" or "дубляж";
         }
 
         static Dictionary<int, string> ParsePlayerjsQualityMap(string file)
@@ -1200,6 +1735,15 @@ namespace Zetflix
                 return text;
 
             return index <= 1 ? "По умолчанию" : $"Озвучка {index}";
+        }
+
+        static string NormalizeObrutSerialVoiceTitle(string text, int index)
+        {
+            text = Regex.Replace(text ?? string.Empty, "\\s+", " ").Trim();
+            if (!string.IsNullOrWhiteSpace(text))
+                return text;
+
+            return index <= 1 ? "Озвучка" : $"Озвучка {index}";
         }
 
         static Dictionary<int, string> ParseObrutQualityMap(string file)

--- a/Modules/OnlineRUS/Zetflix/Service.cs
+++ b/Modules/OnlineRUS/Zetflix/Service.cs
@@ -49,6 +49,9 @@ namespace Zetflix
 
             string file = Regex.Match(html, "file:(\\[[^\n\r]+\\])(,|}\\) ;)").Groups[1].Value;
             if (string.IsNullOrWhiteSpace(file))
+                file = Regex.Match(html, "file:(\\[[\\s\\S]+?\\])\\s*(,|\\}\\) ;)", RegexOptions.Multiline).Groups[1].Value;
+
+            if (string.IsNullOrWhiteSpace(file))
             {
                 file = Regex.Match(html, "file:\"([^\"]+)\"").Groups[1].Value;
                 if (!string.IsNullOrWhiteSpace(file))
@@ -68,7 +71,7 @@ namespace Zetflix
                 return null;
             }
 
-            file = Regex.Replace(file.Trim(), "(\\{|, )([a-z]+): ?", "$1\"$2\":")
+            file = Regex.Replace(file.Trim(), "(\\{|, )([a-zA-Z_][a-zA-Z0-9_]*): ?", "$1\"$2\":")
                         .Replace("},]", "}]");
 
             List<RootObject> pl = null;
@@ -84,7 +87,8 @@ namespace Zetflix
                 return null;
             }
 
-            return new EmbedModel() { pl = pl, movie = !file.Contains("\"comment\":"), quality = quality, check_url = check_url };
+            bool isMovie = !file.Contains("\"comment\":", StringComparison.OrdinalIgnoreCase);
+            return new EmbedModel() { pl = pl, movie = isMovie, quality = quality, check_url = check_url };
         }
 
         public async Task<int> number_of_seasons(long id)


### PR DESCRIPTION
## Summary
- improve Zetflix serial fallback for broken serial responses
- avoid falling back to movie mode for serial requests on the first open
- add broader Playerjs parsing for multi-line file blocks

## What this fixes
- serial pages that first showed a single `По умолчанию` voice and only worked after reopening
- broken season/episode handling for some Zetflix serials
- multi-line `file:` payload parsing in Zetflix responses

## Notes
- based on current upstream `main`
- tested locally in a Docker run with the patched Zetflix module