### PR TITLE
refactor: uniqueness checks for template appends

### DIFF
--- a/Modules/OnlineAnime/Kodik/Service.cs
+++ b/Modules/OnlineAnime/Kodik/Service.cs
@@ -349,14 +349,14 @@ public struct KodikInvoke
                 {
                     int season = item.last_season;
 
-                    if (!hash.Add(season))
-                        continue;
-
-                    tpl.Append(
-                        $"{season} сезон",
-                        host + $"lite/kodik?rjson={rjson}&imdb_id={imdb_id}&kinopoisk_id={kinopoisk_id}&title={enc_title}&original_title={enc_original_title}&clarification={clarification}&pick={enc_pick}&s={season}",
-                        season
-                    );
+                    if (hash.Add(season))
+                    {
+                        tpl.Append(
+                            $"{season} сезон",
+                            host + $"lite/kodik?rjson={rjson}&imdb_id={imdb_id}&kinopoisk_id={kinopoisk_id}&title={enc_title}&original_title={enc_original_title}&clarification={clarification}&pick={enc_pick}&s={season}",
+                            season
+                        );
+                    }
                 }
 
                 return tpl;

--- a/Modules/OnlineAnime/MoonAnime/Controller.cs
+++ b/Modules/OnlineAnime/MoonAnime/Controller.cs
@@ -136,14 +136,14 @@ public class MoonAnimeController : BaseOnlineController
                     {
                         foreach (var season in voice.Value)
                         {
-                            if (!temp.Add(season.Key))
-                                continue;
-
-                            tpl.Append(
-                                $"{season.Key} сезон",
-                                $"{host}/lite/moonanime?rjson={rjson}&title={enc_title}&original_title={enc_original_title}&animeid={animeid}&s={season.Key}",
-                                season.Key
-                            );
+                            if (temp.Add(season.Key))
+                            {
+                                tpl.Append(
+                                    $"{season.Key} сезон",
+                                    $"{host}/lite/moonanime?rjson={rjson}&title={enc_title}&original_title={enc_original_title}&animeid={animeid}&s={season.Key}",
+                                    season.Key
+                                );
+                            }
                         }
                     }
                 }

--- a/Modules/OnlinePaid/Alloha/Controller.cs
+++ b/Modules/OnlinePaid/Alloha/Controller.cs
@@ -165,17 +165,17 @@ public class AllohaController : BaseOnlineController<ModuleConf>
                     {
                         if (translation?.id > 0)
                         {
-                            if (!temp_translation.Add(translation.id))
-                                continue;
+                            if (temp_translation.Add(translation.id))
+                            {
+                                if (activTranslate == -1)
+                                    activTranslate = translation.id;
 
-                            if (activTranslate == -1)
-                                activTranslate = translation.id;
-
-                            vtpl.Append(
-                                translation.name,
-                                activTranslate == translation.id,
-                                $"{host}/lite/alloha?rjson={rjson}&s={s}&t={translation.id}{defaultargs}"
-                            );
+                                vtpl.Append(
+                                    translation.name,
+                                    activTranslate == translation.id,
+                                    $"{host}/lite/alloha?rjson={rjson}&s={s}&t={translation.id}{defaultargs}"
+                                );
+                            }
                         }
                     }
                 }

--- a/Modules/OnlinePaid/Filmix/Controllers/FilmixPartner.cs
+++ b/Modules/OnlinePaid/Filmix/Controllers/FilmixPartner.cs
@@ -142,7 +142,7 @@ public class FilmixPartner : BaseOnlineController<FilmixSettings>
                         int sid = season.Value<int>("season");
                         string sname = $"{sid} сезон";
 
-                        if (!temp_season.Add(sid))
+                        if (temp_season.Add(sid))
                         {
                             tpl.Append(
                                 sname,

--- a/Modules/OnlinePaid/Filmix/Services/FilmixTV.cs
+++ b/Modules/OnlinePaid/Filmix/Services/FilmixTV.cs
@@ -200,14 +200,14 @@ public class FilmixTVInvoke
                 {
                     foreach (var season in translation.Value)
                     {
-                        if (!temp.Add(season.Value.season))
-                            continue;
-
-                        tpl.Append(
-                            $"{season.Value.season} сезон",
-                            $"{host}lite/filmixtv?rjson={rjson}&postid={postid}&title={enc_title}&original_title={enc_original_title}&s={season.Value.season}",
-                            season.Value.season
-                        );
+                        if (temp.Add(season.Value.season))
+                        {
+                            tpl.Append(
+                                $"{season.Value.season} сезон",
+                                $"{host}lite/filmixtv?rjson={rjson}&postid={postid}&title={enc_title}&original_title={enc_original_title}&s={season.Value.season}",
+                                season.Value.season
+                            );
+                        }
                     }
                 }
 

--- a/Modules/OnlineRUS/CDNvideohub/Controller.cs
+++ b/Modules/OnlineRUS/CDNvideohub/Controller.cs
@@ -68,14 +68,14 @@ public class CDNvideohubController : BaseOnlineController
                     {
                         int season = video.season;
 
-                        if (!hash.Add(season))
-                            continue;
-
-                        tpl.Append(
-                            $"{season} сезон",
-                            $"{host}/lite/cdnvideohub?s={season}{defaultargs}",
-                            season
-                        );
+                        if (hash.Add(season))
+                        {
+                            tpl.Append(
+                                $"{season} сезон",
+                                $"{host}/lite/cdnvideohub?s={season}{defaultargs}",
+                                season
+                            );
+                        }
                     }
 
                     return tpl;

--- a/Modules/OnlineRUS/FanCDN/Service.cs
+++ b/Modules/OnlineRUS/FanCDN/Service.cs
@@ -229,14 +229,14 @@ public struct FanCDNInvoke
 
                 foreach (var voice in root.serial.OrderBy(i => i.seasons))
                 {
-                    if (!hash.Add(voice.seasons))
-                        continue;
-
-                    tpl.Append(
-                        $"{voice.seasons} сезон",
-                        host + $"lite/fancdn?rjson={rjson}&imdb_id={imdb_id}&kinopoisk_id={kinopoisk_id}&title={enc_title}&original_title={enc_original_title}&s={voice.seasons}",
-                        voice.seasons
-                    );
+                    if (hash.Add(voice.seasons))
+                    {
+                        tpl.Append(
+                            $"{voice.seasons} сезон",
+                            host + $"lite/fancdn?rjson={rjson}&imdb_id={imdb_id}&kinopoisk_id={kinopoisk_id}&title={enc_title}&original_title={enc_original_title}&s={voice.seasons}",
+                            voice.seasons
+                        );
+                    }
                 }
 
                 return tpl;

--- a/Modules/OnlineRUS/HDVB/Controller.cs
+++ b/Modules/OnlineRUS/HDVB/Controller.cs
@@ -83,14 +83,14 @@ public class HDVBController : BaseOnlineController
                             continue;
 
                         string season_name = $"{season.season_number.Value} сезон";
-                        if (!tmp_season.Add(season_name))
-                            continue;
-
-                        tpl.Append(
-                            season_name,
-                            $"{host}/lite/hdvb?rjson={rjson}&serial=1&kinopoisk_id={kinopoisk_id}&title={enc_title}&original_title={enc_original_title}&s={season.season_number.Value}",
-                            season.season_number.Value
-                        );
+                        if (tmp_season.Add(season_name))
+                        {
+                            tpl.Append(
+                                season_name,
+                                $"{host}/lite/hdvb?rjson={rjson}&serial=1&kinopoisk_id={kinopoisk_id}&title={enc_title}&original_title={enc_original_title}&s={season.season_number.Value}",
+                                season.season_number.Value
+                            );
+                        }
                     }
                 }
 

--- a/Modules/OnlineRUS/Kinogo/Controller.cs
+++ b/Modules/OnlineRUS/Kinogo/Controller.cs
@@ -217,17 +217,17 @@ public class KinogoController : BaseOnlineController
                     foreach (var voice in episode.folder)
                     {
                         int voice_id = voice.voice_id;
-                        if (!hashSet.Add(voice_id))
-                            continue;
+                        if (hashSet.Add(voice_id))
+                        {
+                            if (t == -1)
+                                t = voice_id;
 
-                        if (t == -1)
-                            t = voice_id;
-
-                        vtpl.Append(
-                            voice.title,
-                            t == voice_id,
-                            $"{host}/lite/kinogo?rjson={rjson}&title={enc_title}&original_title={enc_original_title}&year={year}&href={enc_href}&s={s}&t={voice_id}"
-                        );
+                            vtpl.Append(
+                                voice.title,
+                                t == voice_id,
+                                $"{host}/lite/kinogo?rjson={rjson}&title={enc_title}&original_title={enc_original_title}&year={year}&href={enc_href}&s={s}&t={voice_id}"
+                            );
+                        }
                     }
                 }
                 #endregion

--- a/Modules/OnlineRUS/VeoVeo/Controller.cs
+++ b/Modules/OnlineRUS/VeoVeo/Controller.cs
@@ -116,14 +116,14 @@ public class VeoVeoController : BaseOnlineController
                     foreach (var item in cache.Value)
                     {
                         int season = item.season?.order ?? 0;
-                        if (!hash.Add(season))
-                            continue;
-
-                        tpl.Append(
-                            $"{season} сезон",
-                            $"{host}/lite/veoveo?rjson={rjson}&movieid={movieid}&kinopoisk_id={kinopoisk_id}&imdb_id={imdb_id}&title={enc_title}&original_title={enc_original_title}&s={season}",
-                            season
-                        );
+                        if (hash.Add(season))
+                        {
+                            tpl.Append(
+                                $"{season} сезон",
+                                $"{host}/lite/veoveo?rjson={rjson}&movieid={movieid}&kinopoisk_id={kinopoisk_id}&imdb_id={imdb_id}&title={enc_title}&original_title={enc_original_title}&s={season}",
+                                season
+                            );
+                        }
                     }
 
                     return tpl;

--- a/Modules/OnlineUKR/Ashdi/Service.cs
+++ b/Modules/OnlineUKR/Ashdi/Service.cs
@@ -134,18 +134,18 @@ public struct AshdiInvoke
                     {
                         foreach (var season in voice.folder)
                         {
-                            if (!hashseason.Add(season.title))
-                                continue;
+                            if (hashseason.Add(season.title))
+                            {
+                                string numberseason = Regex.Match(season.title, "([0-9]+)$").Groups[1].Value;
+                                if (string.IsNullOrEmpty(numberseason))
+                                    continue;
 
-                            string numberseason = Regex.Match(season.title, "([0-9]+)$").Groups[1].Value;
-                            if (string.IsNullOrEmpty(numberseason))
-                                continue;
-
-                            tpl.Append(
-                                season.title,
-                                host + $"lite/ashdi?rjson={rjson}&title={enc_title}&original_title={enc_original_title}&uri={enc_uri}&s={numberseason}",
-                                numberseason
-                            );
+                                tpl.Append(
+                                    season.title,
+                                    host + $"lite/ashdi?rjson={rjson}&title={enc_title}&original_title={enc_original_title}&uri={enc_uri}&s={numberseason}",
+                                    numberseason
+                                );
+                            }
                         }
                     }
 

--- a/Modules/OnlineUKR/HdvbUA/Service.cs
+++ b/Modules/OnlineUKR/HdvbUA/Service.cs
@@ -147,17 +147,17 @@ public struct HdvbUAInvoke
 
                     for (int i = 0; i < season.folder.Length; i++)
                     {
-                        if (!hash.Add(season.folder[i].title))
-                            continue;
+                        if (hash.Add(season.folder[i].title))
+                        {
+                            if (t == -1)
+                                t = i;
 
-                        if (t == -1)
-                            t = i;
-
-                        vtpl.Append(
-                            season.folder[i].title,
-                            t == i,
-                            host + $"lite/hdvbua?rjson={rjson}&title={enc_title}&original_title={enc_original_title}&uri={enc_uri}&s={s}&t={i}"
-                        );
+                            vtpl.Append(
+                                season.folder[i].title,
+                                t == i,
+                                host + $"lite/hdvbua?rjson={rjson}&title={enc_title}&original_title={enc_original_title}&uri={enc_uri}&s={s}&t={i}"
+                            );
+                        }
                     }
                     #endregion
 

--- a/Modules/OnlineUKR/Tortuga/Service.cs
+++ b/Modules/OnlineUKR/Tortuga/Service.cs
@@ -162,17 +162,17 @@ public struct TortugaInvoke
                     {
                         foreach (var voice in episode.folder)
                         {
-                            if (!hashVoice.Add(voice.title))
-                                continue;
+                            if (hashVoice.Add(voice.title))
+                            {
+                                if (string.IsNullOrEmpty(t))
+                                    t = voice.title;
 
-                            if (string.IsNullOrEmpty(t))
-                                t = voice.title;
-
-                            vtpl.Append(
-                                voice.title,
-                                t == voice.title,
-                                host + $"lite/tortuga?rjson={rjson}&title={enc_title}&original_title={enc_original_title}&uri={enc_uri}&s={s}&t={voice.title}"
-                            );
+                                vtpl.Append(
+                                    voice.title,
+                                    t == voice.title,
+                                    host + $"lite/tortuga?rjson={rjson}&title={enc_title}&original_title={enc_original_title}&uri={enc_uri}&s={s}&t={voice.title}"
+                                );
+                            }
                         }
                     }
                     #endregion


### PR DESCRIPTION
Refactored code to use if-blocks for HashSet uniqueness checks before appending to templates, replacing early-continue patterns. This improves readability and keeps related logic together, including any dependent default value assignments.