### PR TITLE
fix(Tg-notify.bot): plugin path resolution and replace hardcoded host

### DIFF
--- a/Modules/Tg-notify.bot/Controllers/TgNotifyController.cs
+++ b/Modules/Tg-notify.bot/Controllers/TgNotifyController.cs
@@ -18,6 +18,7 @@ namespace TelegramBot.Controllers
             string file = null;
             foreach (var p in new[]
             {
+                "module/Tg-notify.bot/tg-notify.js",
                 "module/Community/Tg-notify.bot/tg-notify.js",
                 "mods/TelegramBot/tg-notify.js",
                 "module/TelegramBot/tg-notify.js",

--- a/Modules/Tg-notify.bot/tg-notify.js
+++ b/Modules/Tg-notify.bot/tg-notify.js
@@ -1,7 +1,7 @@
 (function () {
     'use strict';
 
-    var lampac_host = 'https://hanzoon.online';
+    var lampac_host = '{localhost}';
     var network = new Lampa.Reguest();
 
     function getToken() {


### PR DESCRIPTION
Контроллер TgNotifyController.TgNotifyPlugin() ищет файл плагина по списку путей, но реальная структура модуля на сервере - module/Tg-notify.bot/tg-notify.js - не входит в этот список. В результате File.Exists(p) не находит файл ни разу,  и /tg-notify.js всегда отдаёт пустое тело с кодом 200 OK без ошибок в логе.

Добавлен путь "module/Tg-notify.bot/tg-notify.js" в начало списка поиска.

Проверено на живом сервере: curl http://127.0.0.1:9118/tg-notify.js до правки - Content-Length: 0, после правки - отдаёт полное содержимое плагина.

Дополнительно: в tg-notify.js была захардкожена переменная lampac_host со сторонним доменом (https://hanzoon.online) вместо плейсхолдера {localhost},  который контроллер заменяет на реальный хост через js.Replace("{localhost}", host). Из-за этого плагин у пользователей стучался не на их собственный сервер.