### PR TITLE
fix: update Lenkino NextHUB source

### DIFF
--- a/Modules/NextHUB/sites/lenkino.yaml
+++ b/Modules/NextHUB/sites/lenkino.yaml
@@ -4,6 +4,7 @@ displayname: Lenkino
 rch_access: apk,cors
 stream_access: apk,cors
 rchstreamproxy: web
+streamproxy: true
 host: https://wes.lenkino.adult
 priorityBrowser: http
 streamproxy_preview: true
@@ -133,6 +134,47 @@ menu:
     Глотает сперму: cum-swallow
     Сперма на попе: cum-on-ass
     Сперма на пизде: cum-on-pussy
+  customs:
+    - name: Студии
+      arg: studio
+      format: "channel/{value}/page/{page}"
+      submenu:
+        Perv Mom: pervmom
+        Pornhub: pornhub
+        Brazzers Exxtra: brazzers-exxtra
+        Bratty Sis: bratty-sis
+        Sis Loves Me: sis-loves-me
+        My Pervy Family: my-pervy-family
+        Anal Mom: anal-mom
+        "My Friend's Hot Mom": my-friends-hot-mom
+        Moms Teach Sex: momsteachsex
+        Family Strokes: family-strokes
+        Tushy: tushy
+        Blacked: blacked
+        Evil Angel: evilangel
+        Dad Crush: dadcrush
+        Sex Mex: sexmex
+        Family Therapy: family-therapy
+        Vixen: vixen
+        Freeuse Milf: freeusemilf
+        Milfy: milfy
+        "Cum 4K": cum4k
+        "Mom Swap": mom-swap
+        "Public Agent": publicagent
+        "Pure Taboo": pure-taboo
+        "My Family Pies": myfamilypies
+        "Freeuse Fantasy": freeuse-fantasy
+        ShopLyfter: shop-lyfter
+        Exxxtra Small: exxxtra-small
+        "Nubile Films": nubilefilms
+        "Fake Taxi": faketaxi
+        "Fake Hostel": fakehostel
+        "Bratty Milf": bratty-milf
+        "Let's Post It": let-s-post-it
+        "Tiny 4K": tiny4k
+        "Porn World": pornworld-com
+        "Hunt 4K": hunt-4k
+        "Club Sweethearts": club-sweethearts
 
 list:
   uri: "page/{page}"
@@ -141,7 +183,7 @@ search:
   uri: "search/{search}/page/{page}"
 
 contentParse:
-  nodes: //div[@class='item']
+  nodes: //div[@id='list_videos_videos_list_items']/div[contains(@class,'item')]
   name:
     node: .//div[@class='itm-tit']
   href:
@@ -165,6 +207,29 @@ contentParse:
 view:
   related: true
   viewsource: true
-  regexMatch:
-    matches: ["alt_url", "url"]
-    pattern: "video_{value}:[\t ]+'([^']+)'"
+  eval: |
+    string decodeLenkino()
+    {
+      foreach (string q in new string[] { "alt_url5", "alt_url4", "alt_url3", "alt_url2", "alt_url", "alt_url1", "url", "url_text" })
+      {
+        string l = Regex.Match(html, $"video_{q}:[\t ]+'([^']+)'", RegexOptions.IgnoreCase).Groups[1].Value;
+        if (!string.IsNullOrEmpty(l) && l.Contains("/get_file/"))
+          return l.Replace("function/0/", "");
+      }
+
+      foreach (string q in new string[] { "1080p", "720p", "480p", "360p" })
+      {
+        string l = Regex.Match(html, $"(https?://[^/]+/get_file/[^\"]+_{q}\\.mp4([^\"]+)?)('|\")", RegexOptions.IgnoreCase).Groups[1].Value;
+        if (!string.IsNullOrEmpty(l))
+          return l.Replace("function/0/", "");
+      }
+
+      string link = Regex.Match(html, "(https?://[^/]+/get_file/[^'\"]+\\.mp4([^'\"]+)?)('|\")", RegexOptions.IgnoreCase).Groups[1].Value;
+      if (string.IsNullOrEmpty(link))
+        return null;
+
+      return link.Replace("function/0/", "");
+    }
+
+    headers.Add(new Shared.Models.Base.HeadersModel("referer", url));
+    return decodeLenkino();


### PR DESCRIPTION
## Summary
- enable stream proxy for Lenkino NextHUB source
- tighten list parsing to the main video list container
- add Lenkino studio menu entries
- update playback extraction for current Lenkino player variables (`video_alt_url` / `video_url`) without applying the old KT hash transform that now produces 404 links
- keep `Referer` on extracted streams

## Verification
- local Lampac/NextHUB list returns Lenkino items
- `GET /nexthub/vidosik?...` returns `qualitys.auto`
- proxy Range request returns `206 video/mp4` and MP4 bytes for tested Lenkino cards
- user confirmed playback works locally