### PR TITLE
fix(NextHUB): use mobile source for sex-studentki

### DIFF
--- a/Modules/NextHUB/sites/sex-studentki.yaml
+++ b/Modules/NextHUB/sites/sex-studentki.yaml
@@ -6,8 +6,11 @@ stream_access: apk
 host: https://sex-studentki.live
 priorityBrowser: http
 streamproxy: true
+headers:
+  user-agent: "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Mobile/15E148 Safari/604.1"
 headers_stream:
   referer: "{host}/"
+  user-agent: "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Mobile/15E148 Safari/604.1"
 
 list:
   uri: videos?page={page}
@@ -48,7 +51,7 @@ view:
 #  waitLocationFile: true
   viewsource: true
   regexMatch:
-    pattern: '<source[\t ]+src="([^\"]+)"'
+    pattern: '<video[^>]+id="player"[\s\S]*?<source[\t ]+src="([^\"]+/link_cs/[^\"]+)"'
   related: true
   relatedParse:
     nodes: //div[@class='video mini trailer']


### PR DESCRIPTION
## Что изменено

- добавлен мобильный user-agent для sex-studentki
- тот же user-agent передаётся при запросе stream
- regex источника ограничен реальным `/link_cs/` внутри `<video id="player">`

## Зачем

На desktop-версии сайт может не отдавать рабочий video source, а мобильная версия отдаёт ссылку `/link_cs/...`.

## Проверка

- локально проверено на рабочей конфигурации NextHUB
- PR содержит только `Modules/NextHUB/sites/sex-studentki.yaml`