### PR TITLE
feat(Music): make Apple Music country configurable

### DIFF
--- a/Modules/Music/ModInit.cs
+++ b/Modules/Music/ModInit.cs
@@ -52,6 +52,7 @@ public class ModInit : IModuleLoaded, IModuleConfigure
             soundcloud_discovery_enabled = true,
             soundcloud_audio_enabled = true,
             soundcloud_auth_enabled = false,
+            applemusic_country = "us",
             soundcloud_client_id = "",
             soundcloud_client_secret = "",
             soundcloud_redirect_uri = "",

--- a/Modules/Music/ModuleConf.cs
+++ b/Modules/Music/ModuleConf.cs
@@ -36,6 +36,8 @@ public class ModuleConf
 
     public bool soundcloud_auth_enabled { get; set; }
 
+    public string applemusic_country { get; set; }
+
     public string soundcloud_client_id { get; set; }
 
     public string soundcloud_client_secret { get; set; }

--- a/Modules/Music/Providers/Discovery/AppleMusic/AppleMusicDiscoveryProvider.cs
+++ b/Modules/Music/Providers/Discovery/AppleMusic/AppleMusicDiscoveryProvider.cs
@@ -12,7 +12,7 @@ public class AppleMusicDiscoveryProvider : IMusicDiscoveryProvider
     static readonly TimeSpan cacheTtl = TimeSpan.FromHours(6);
 
     const string providerId = "applemusiccharts";
-    const string country = "us";
+    const string defaultCountry = "us";
     const string userAgent = "LampacNextgenMusic/0.1 (https://github.com/lampac-nextgen/lampac)";
 
     public string Id => providerId;
@@ -104,17 +104,19 @@ public class AppleMusicDiscoveryProvider : IMusicDiscoveryProvider
 
     async Task<List<MusicAlbum>> GetTopAlbumsAsync(CancellationToken cancellationToken)
     {
+        string country = GetCountry();
+
         return await MusicMetadataCacheService.GetOrCreateAsync(
             providerId,
             "browse",
             $"{country}:top-albums",
             cacheTtl,
-            () => LoadTopAlbumsAsync(cancellationToken),
+            () => LoadTopAlbumsAsync(country, cancellationToken),
             cancellationToken
         ) ?? new List<MusicAlbum>();
     }
 
-    async Task<List<MusicAlbum>> LoadTopAlbumsAsync(CancellationToken cancellationToken)
+    async Task<List<MusicAlbum>> LoadTopAlbumsAsync(string country, CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"https://rss.marketingtools.apple.com/api/v2/{country}/music/most-played/100/albums.json");
         request.Headers.TryAddWithoutValidation("User-Agent", userAgent);
@@ -135,6 +137,16 @@ public class AppleMusicDiscoveryProvider : IMusicDiscoveryProvider
             .Select(node => ParseAlbum(node as JsonObject))
             .Where(i => i != null)
             .ToList();
+    }
+
+    static string GetCountry()
+    {
+        string country = ModInit.conf?.applemusic_country;
+        if (string.IsNullOrWhiteSpace(country))
+            return defaultCountry;
+
+        country = country.Trim().ToLowerInvariant();
+        return Regex.IsMatch(country, "^[a-z]{2}$") ? country : defaultCountry;
     }
 
     static MusicAlbum ParseAlbum(JsonObject item)

--- a/Modules/Music/README.md
+++ b/Modules/Music/README.md
@@ -103,6 +103,7 @@ curl -fsS 'http://127.0.0.1:9118/music/providers'
 ```jsonc
 {
   "Music": {
+    "applemusic_country": "ru",
     "soundcloud_country": "DE",
     "z3fm_enabled": true,
     "z3fm_audio_enabled": true
@@ -125,6 +126,7 @@ curl -fsS 'http://127.0.0.1:9118/music/providers'
 | `soundcloud_discovery_enabled` | `true` | полки/подборки SoundCloud |
 | `soundcloud_audio_enabled` | `true` | SoundCloud как audio-источник |
 | `soundcloud_auth_enabled` | `false` | вход в аккаунт SoundCloud (OAuth) |
+| `applemusic_country` | `us` | регион Apple Music Charts (ISO 3166-1 alpha-2) |
 | `soundcloud_client_id` | *(пусто)* | собственный client_id; без него скрапится публичный |
 | `soundcloud_client_secret` | *(пусто)* | для OAuth-потока |
 | `soundcloud_redirect_uri` | *(пусто)* | для OAuth-потока |


### PR DESCRIPTION
Fixes #151.

## Что изменено
- добавлен `Music.applemusic_country` со значением по умолчанию `us`
- страна используется в Apple Music Charts RSS URL и ключе кэша
- настройка добавлена в README