### PR TITLE
feat(LampaWeb): add telegramAuthGate flag

### DIFF
--- a/Modules/Community/README.md
+++ b/Modules/Community/README.md
@@ -23,6 +23,7 @@
 2. **`mutations_api_secret`** должен **совпадать** в обоих модулях (и быть ненулевым в проде, если нужны бот-админка и защищённый `bind/complete`).
 3. Включить модули в `manifest.json` (`"enable": true`).
 4. Для входа через accsdb: **`TelegramAuth.enable`: `true`** поднимает **`accsdb.enable`** в Core и синхронизирует привязанные UID в корневой **`users.json`**. Без этого API Telegram живёт, но «дверь» accsdb не заведётся из TelegramAuth.
+5. Чтобы вход был через Telegram (а не модалку пароля/CUB), добавьте флаг **`telegramAuthGate`** в конфиг LampaWeb — см. раздел «Как заменить стандартный deny.js на Telegram» ниже.
 
 ## Клиент Lampa: `deny.js` и `telegram_auth_gate.js`
 
@@ -31,8 +32,8 @@
 ### Где это подключается
 
 - В **`lampainit.js`** в функции `start()` есть плейсхолдер **`{deny}`**.
-- [ApiController.cs](../../LampaWeb/Controllers/ApiController.cs) при **`accsdb.enable`** подставляет в `{deny}` **содержимое файла** `Modules/LampaWeb/plugins/deny.js` (с заменой `{cubMesage}` на `accsdb.authMesage`). Если accsdb выключен, `{deny}` очищается.
-- Скрипт **`telegram_auth_gate.js`** отдаётся отдельным маршрутом **`GET …/telegram_auth_gate.js`** с подстановкой `{localhost}` и `{country}` (как у других плагинов LampaWeb).
+- [ApiController.cs](../../LampaWeb/Controllers/ApiController.cs) при **`accsdb.enable`** подставляет в `{deny}` **содержимое файла** `Modules/LampaWeb/plugins/deny.js` (с заменой `{cubMesage}` на `accsdb.authMesage`) — или `telegram_auth_gate.js` при включённом флаге `telegramAuthGate` (см. раздел «Как заменить стандартный deny.js на Telegram»). Если accsdb выключен, `{deny}` очищается.
+- Скрипт **`telegram_auth_gate.js`** отдаётся отдельным маршрутом **`GET …/telegram_auth_gate.js`** с подстановкой `{localhost}`, `{country}`, `{token}` (как у других плагинов LampaWeb), а также `{botUsername}`/`{serviceName}` из конфига `telegramAuthGate` (через `TelegramGateJs()`). При вставке в `{deny}` сервер подставляет только `{botUsername}`/`{serviceName}` (остальные плейсхолдеры подставляются глобально на этапе сборки `lampainit.js`).
 
 ### Что делает `deny.js` (стандарт)
 
@@ -43,18 +44,50 @@
 
 - Тот же запрос к **`/testaccsdb`**, но **не** трогает `start_deep_link` (нет принудительного экрана deny в ядре Lampa).
 - Показывает полноэкранный оверлей: **UID устройства**, кнопка «Открыть Telegram», QR (на крупных экранах), опрос **`GET /tg/auth/status?uid=...`** каждые `checkIntervalMs`.
-- После успеха пишет профиль в `Lampa.Storage` (`tg_auth_user`), отправляет **`POST /tg/auth/device/name`**, снимает блокировку и делает **перезагрузку на главную** (как после успешного пароля в `deny.js`).
-- В начале файла нужно задать **`CONFIG.botUsername`** и **`CONFIG.serviceName`** (без `@` у имени бота в логике допускается — код обрежет).
+- После успеха пишет профиль в `Lampa.Storage` (`tg_auth_user`), отправляет **`POST /tg/auth/device/name`**, снимает блокировку и делает **перезагрузку на главную** (как после успешного пароля в `deny.js`). Блокировка окончательно снимается после повторного опроса `/testaccsdb` на перезагруженной странице: гейт не использует `start_deep_link` ядра Lampa, поэтому именно reload запускает повторную проверку, которая видит авторизацию. Убедитесь, что подключён ровно один источник гейта, иначе будет двойной опрос `/testaccsdb`.
+- В начале файла нужно задать **`CONFIG.botUsername`** и **`CONFIG.serviceName`** (без `@` у имени бота в логике допускается — код обрежет). Актуально только при подключении скрипта вручную (customPlugins или подмена файла); при конфиге `telegramAuthGate` значения приходят из него.
 
-### Как заменить стандартный `deny.js` на Telegram
+### Как заменить стандартный deny.js на Telegram
 
 Нужно, чтобы при включённом accsdb в `start()` выполнялся **только** сценарий с Telegram, а не модалка пароля/CUB.
 
-**Способ 1 (рекомендуется):** подменить содержимое **`Modules/LampaWeb/plugins/deny.js`** копией **`telegram_auth_gate.js`**, выставить `CONFIG`, при необходимости поправить тексты. Сервер по-прежнему вставит этот файл в `{deny}` — отдельно подключать URL `telegram_auth_gate.js` не нужно, подставятся `{localhost}` и `{token}` на этапе сборки ответа `lampainit.js`.
+**Рекомендуемый способ — флаг в конфиге (без правки файлов)**
 
-**Способ 2:** очистить **`deny.js`** (или оставить минимальный пустой блок), а **`telegram_auth_gate.js`** добавить в список плагинов LampaWeb (**`customPlugins`** в конфиге модуля LampaWeb) с URL вида `{localhost}/telegram_auth_gate.js` и `status: 1`. Тогда `{deny}` не выполняет проверку, а гейт загрузится вместе с остальными плагинами после `start()`. Убедитесь, что **не** подключены оба полноценных скрипта сразу — будет двойной опрос `/testaccsdb`.
+1. В `init.conf` (или merge-файле) убедитесь, что **`accsdb.enable: true`**.
+2. Добавьте блок **`telegramAuthGate`** с `enabled: true` и **непустым** `botUsername` (непустой = не состоящий из одних пробелов; код проверяет `IsNullOrWhiteSpace`).
+3. Перезапустите LampaWeb.
 
-**Способ 3:** держать кастомную ветку **`lampainit.js`** / правку **ApiController**, если нужна явная опция в конфиге «deny vs telegram» без замены файлов на диске (в текущем репозитории отдельного флага нет).
+Пример (`init.conf` или merge-файл):
+```json
+{
+  "LampaWeb": {
+    "telegramAuthGate": {
+      "enabled": true,
+      "botUsername": "lampac_community_bot",
+      "serviceName": "lampa"
+    }
+  }
+}
+```
+
+> Гейт активируется только при выполнении всех условий: `accsdb.enable` + `telegramAuthGate.enabled` + непустой `botUsername`. Иначе — **тихий откат на стандартный `deny.js` с warning** в логе. Override файла через `FileCache` кэшируется ~10 мин.
+
+Семантика полей: `enabled` — вкл/выкл подстановку гейта; `botUsername` — имя бота **без `@`** (код обрезает ведущий `@`); `serviceName` — отображаемое имя сервиса в текстах оверлея гейта.
+
+**Альтернатива — файловый оверрайд (подмена deny.js)**
+
+Скопируйте содержимое `telegram_auth_gate.js` поверх `Modules/LampaWeb/plugins/deny.js` и задайте `CONFIG.botUsername` / `CONFIG.serviceName` в начале файла вручную. Работает, но правка теряется при обновлении — предпочтителен флаг выше.
+
+⚠️ **Двойной опрос `/testaccsdb`**: `customPlugins` добавляется независимо от флага (см. `ApiController.cs:650-657`). Актуально только при ручном подключении скрипта, а не при использовании флага.
+
+<details>
+<summary>Прочие / продвинутые варианты</summary>
+
+- **Гейт как отдельный плагин (`customPlugins`)** — очистите `deny.js` и добавьте URL `{localhost}/telegram_auth_gate.js` со `status: 1`; гейт загружается после `start()` вместе с плагинами. Нишевый сценарий; сохраняется предупреждение о двойном опросе выше.
+- **Своя ветка / правка исходников** — для разработчиков: точка расширения выбора скрипта для `{deny}` в `ApiController.cs:671-693`.
+- **Override через `FileCache`** — файл `telegram_auth_gate.js` можно переопределить через `plugins/override/telegram_auth_gate.js` (см. корневой `README.md`, раздел override); свежий override может занять до ~10 мин из-за кэша `FileCache.cs:54`.
+
+</details>
 
 ### Плейсхолдеры в плагинах
 
@@ -63,6 +96,8 @@
 | `{localhost}` | Базовый URL Lampac для запросов |
 | `{token}` | Из `accsdb.domainId_pattern` (если задан), иначе пусто |
 | `{cubMesage}` | Только в **`deny.js`** при вставке в `lampainit` → `accsdb.authMesage` |
+| `{botUsername}` | Только в **`telegram_auth_gate.js`** (через `TelegramGateJs()`) из `telegramAuthGate.botUsername`; экранируется `JavaScriptStringEncode` |
+| `{serviceName}` | Только в **`telegram_auth_gate.js`** (через `TelegramGateJs()`) из `telegramAuthGate.serviceName`; экранируется `JavaScriptStringEncode` |
 
 В **`telegram_auth_gate.js`** для подсказок с сервера используются поля ответа **`/testaccsdb`**: `msg`, `denymsg`, `newuid` (как в `deny.js`).
 

--- a/Modules/LampaWeb/Controllers/ApiController.cs
+++ b/Modules/LampaWeb/Controllers/ApiController.cs
@@ -670,14 +670,26 @@ public class ApiController : BaseController
 
             if (CoreInit.conf.accsdb.enable)
             {
-                string denyjs = FileCache.ReadAllText($"{ModInit.modpath}/plugins/deny.js", "deny.js");
-                if (denyjs.Contains("{country}"))
-                    StatiCacheDisabled = true;
+                string script;
+                var gate = ModInit.conf.telegramAuthGate;
+                if (gate != null && gate.enabled && !string.IsNullOrWhiteSpace(gate.botUsername))
+                {
+                    script = TelegramGateJs();
+                }
+                else
+                {
+                    if (gate != null && gate.enabled && string.IsNullOrWhiteSpace(gate.botUsername))
+                        Console.WriteLine("LampaWeb.telegramAuthGate: enabled=true, но botUsername пустой — откат на deny.js (гейт без имени бота неавторизуем).");
 
-                if (denyjs.Contains("{cubMesage}"))
-                    denyjs = denyjs.Replace("{cubMesage}", CoreInit.conf.accsdb.authMesage);
+                    script = FileCache.ReadAllText($"{ModInit.modpath}/plugins/deny.js", "deny.js");
+                    if (script.Contains("{country}"))
+                        StatiCacheDisabled = true;
 
-                sb = sb.Replace("{deny}", denyjs);
+                    if (script.Contains("{cubMesage}"))
+                        script = script.Replace("{cubMesage}", CoreInit.conf.accsdb.authMesage);
+                }
+
+                sb = sb.Replace("{deny}", script);
             }
 
             string initinvcjs = FileCache.ReadAllText($"{ModInit.modpath}/plugins/lampainit-invc.js", "lampainit-invc.js");
@@ -894,6 +906,22 @@ public class ApiController : BaseController
     }
     #endregion
 
+    private string TelegramGateJs()
+    {
+        var g = ModInit.conf.telegramAuthGate;
+        string raw = FileCache.ReadAllText($"{ModInit.modpath}/plugins/telegram_auth_gate.js", "telegram_auth_gate.js");
+        if (raw.Contains("{country}"))
+            StatiCacheDisabled = true; // defensive parity с deny.js; в файле гейта {country} нет
+
+        string bot = HttpUtility.JavaScriptStringEncode(g?.botUsername ?? string.Empty);
+        string svc = HttpUtility.JavaScriptStringEncode(g?.serviceName ?? string.Empty);
+
+        // {localhost}, {country}, {token} подставляются глобально (688-689, 738-748) или в маршруте
+        return raw
+            .Replace("{botUsername}", bot)
+            .Replace("{serviceName}", svc);
+    }
+
     #region telegram_auth_gate.js
     [HttpGet, AllowAnonymous, Staticache(manually: true)]
     [Route("telegram_auth_gate.js")]
@@ -901,9 +929,14 @@ public class ApiController : BaseController
     {
         SetHeadersNoCache();
 
-        string gate = FileCache.ReadAllText($"{ModInit.modpath}/plugins/telegram_auth_gate.js", "telegram_auth_gate.js")
-            .Replace("{country}", requestInfo.Country)
-            .Replace("{localhost}", host);
+        string token = string.IsNullOrEmpty(CoreInit.conf.accsdb.domainId_pattern)
+            ? string.Empty
+            : Regex.Match(HttpContext.Request.Host.Host, CoreInit.conf.accsdb.domainId_pattern).Groups[1].Value;
+
+        string gate = TelegramGateJs()
+            .Replace("{country}", requestInfo.Country ?? string.Empty)
+            .Replace("{localhost}", host)
+            .Replace("{token}", HttpUtility.UrlEncode(token));
 
         return ContentTo(gate, "application/javascript; charset=utf-8");
     }

--- a/Modules/LampaWeb/LampaWeb.csproj
+++ b/Modules/LampaWeb/LampaWeb.csproj
@@ -20,6 +20,9 @@
     <None Update="plugins\deny.js">
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
     </None>
+    <None Update="plugins\telegram_auth_gate.js">
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </None>
     <None Update="plugins\dorama.js">
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
     </None>

--- a/Modules/LampaWeb/Models/ModuleConf.cs
+++ b/Modules/LampaWeb/Models/ModuleConf.cs
@@ -25,6 +25,8 @@ public class ModuleConf : ModuleBaseConf
 
     public WidgetsConf widgets { get; set; } = new();
 
+    public TelegramAuthGateConf telegramAuthGate { get; set; } = new();
+
     public Dictionary<string, string> appReplace { get; set; }
 
     public Dictionary<string, string> cssReplace { get; set; }

--- a/Modules/LampaWeb/Models/TelegramAuthGateConf.cs
+++ b/Modules/LampaWeb/Models/TelegramAuthGateConf.cs
@@ -1,0 +1,8 @@
+namespace LampaWeb;
+
+public class TelegramAuthGateConf
+{
+    public bool enabled { get; set; }
+    public string botUsername { get; set; }
+    public string serviceName { get; set; }
+}

--- a/Modules/LampaWeb/plugins/telegram_auth_gate.js
+++ b/Modules/LampaWeb/plugins/telegram_auth_gate.js
@@ -5,8 +5,8 @@
   window.telegram_auth_gate_loaded = true;
 
   var CONFIG = {
-    botUsername: 'YOUR_BOT_USERNAME',
-    serviceName: 'YOUR_SERVICE_NAME',
+    botUsername: '{botUsername}',
+    serviceName: '{serviceName}',
     lsUidKey: 'lampac_unic_id',
     lsUserKey: 'tg_auth_user',
     checkIntervalMs: 10000,
@@ -513,8 +513,7 @@
     if (email) url = Lampa.Utils.addUrlComponent(url, 'account_email=' + encodeURIComponent(email));
     var uid0 = Lampa.Storage.get(CONFIG.lsUidKey, '');
     if (uid0) url = Lampa.Utils.addUrlComponent(url, 'uid=' + encodeURIComponent(uid0));
-    var token = '{token}';
-    if (token) url = Lampa.Utils.addUrlComponent(url, 'token={token}');
+    url = Lampa.Utils.addUrlComponent(url, 'token={token}');
     return url;
   }
 


### PR DESCRIPTION
## Контекст

Раньше, чтобы заменить стандартный экран блокировки `deny.js` на экран авторизации через Telegram, администратору приходилось одним из трёх способов: вручную перезаписать файл `deny.js` копией скрипта авторизации, подключить авторизацию через Telegram как отдельный плагин через `customPlugins` или править исходники `lampainit.js`/`ApiController`. Это усложняло настройку и размывало «рекомендованный» путь.

Добавлен декларативный флаг в конфиге LampaWeb, при котором сервер сам подставляет `telegram_auth_gate.js` в плейсхолдер `{deny}` — без правки файлов на диске.

## Изменения

- Добавлена модель `TelegramAuthGateConf` (`enabled`, `botUsername`, `serviceName`) и свойство `telegramAuthGate` в `ModuleConf`.
- Добавлен хелпер `TelegramGateJs()`: читает `telegram_auth_gate.js`, экранирует `botUsername`/`serviceName` через `HttpUtility.JavaScriptStringEncode` и подставляет плейсхолдеры `{botUsername}`/`{serviceName}`.
- В блоке `accsdb.enable` сервер подставляет экран авторизации в `{deny}`, когда выполнены все условия: `accsdb.enable` + `telegramAuthGate.enabled` + непустой `botUsername` (не из одних пробелов). Иначе подставляется стандартный `deny.js` — поведение без изменений. Пустой `botUsername` при включённом флаге → тихий откат на `deny.js` + warning в лог.
- Исправлен standalone-маршрут `GET …/telegram_auth_gate.js`: добавлена подстановка `{token}` из `accsdb.domainId_pattern` (с `UrlEncode`).
- `telegram_auth_gate.js` добавлен в публикацию (`LampaWeb.csproj`, `CopyToPublishDirectory=Always`) — ранее файл мог отсутствовать в собранном артефакте.
- В `telegram_auth_gate.js` убран мёртвый код (`var token = '{token}'; if (token) …`).
- Документация `Modules/Community/README.md`: флаг `telegramAuthGate` вынесен как единственный рекомендованный способ (3-шаговый быстрый старт), альтернативные методы свёрнуты в `<details>`.

## Тестирование

- Сборка: `dotnet build Modules/LampaWeb/LampaWeb.csproj -c Debug` → 0 ошибок / 0 предупреждений.
- `node --check Modules/LampaWeb/plugins/telegram_auth_gate.js` → OK.
- Ручная проверка: при `accsdb.enable: true` + `telegramAuthGate.enabled: true` + непустом `botUsername` экран авторизации подставляется в `{deny}`; при выключенном флаге или пустом `botUsername` — стандартный `deny.js`.

## Замечания для ревью

- Экранирование `botUsername`/`serviceName` через `JavaScriptStringEncode` защищает от выхода из одинарных JS-кавычек в `CONFIG`.
- Асимметрия кодирования `{token}`: в standalone-маршруте — `UrlEncode`, при инлайне в `{deny}` — raw (совпадает с существующим поведением `deny.js`/`dorama.js`); для доменных токенов безопасно.
- Обратная совместимость: старый метод «замена файла» теперь требует ручной правки плейсхолдеров `{botUsername}`/`{serviceName}` (они больше не хардкодятся); метод `customPlugins` без флага и без файлового оверрайда выдаст пустой `botUsername`.