### PR TITLE
feat(Music): enable standalone player for all platforms

### DIFF
--- a/Modules/Music/plugin.js
+++ b/Modules/Music/plugin.js
@@ -1500,6 +1500,8 @@
             values.outplayer = 'Outplayer';
             values.nplayer = 'nPlayer';
             values.infuse = 'Infuse';
+        } else if (!Lampa.Platform.macOS()) {
+            values.ios = 'Music Player';
         }
 
         if (Lampa.Platform.macOS()) {
@@ -4953,8 +4955,7 @@
     // --- standalone <audio>: элемент, timeupdate, lock-kick ---
 
     function shouldUseStandaloneIosAudio() {
-        return Lampa.Platform.is('apple')
-            && currentExternalPlayer() === 'ios'
+        return currentExternalPlayer() === 'ios'
             && getPlaybackMode() === 'audio';
     }
 
@@ -9383,9 +9384,29 @@
 
     function pickPlaybackSource(sources) {
         if (!Array.isArray(sources) || !sources.length) return null;
-        if (!shouldUseStandaloneIosAudio()) return sources[0];
 
-        return sources.slice().sort(function (a, b) {
+        function isHls(s) {
+            var quality = String(s && s.quality || '').toLowerCase();
+            var protocol = String(s && s.protocol || '').toLowerCase();
+            var mime = String(s && s.mime_type || '').toLowerCase();
+            var url = String(s && s.url || '').toLowerCase();
+            return quality.indexOf('hls') !== -1
+                || protocol.indexOf('hls') !== -1
+                || mime.indexOf('mpegurl') !== -1
+                || url.indexOf('.m3u8') !== -1;
+        }
+
+        if (!shouldUseStandaloneIosAudio()) {
+            var nonHls = sources.filter(function (s) { return !isHls(s); });
+            return nonHls.length ? nonHls[0] : sources[0];
+        }
+
+        var candidates = Lampa.Platform.is('apple')
+            ? sources
+            : sources.filter(function (s) { return !isHls(s); });
+        if (!candidates.length) candidates = sources;
+
+        return candidates.slice().sort(function (a, b) {
             return iosSourceRank(a) - iosSourceRank(b);
         })[0];
     }
@@ -10529,7 +10550,7 @@
 
         if (!player) return true;
         if (player === 'inner' || player === 'lampa') return true;
-        if (Lampa.Platform.is('apple') && player === 'ios') return true;
+        if (player === 'ios') return true;
 
         return false;
     }


### PR DESCRIPTION
## Проблема

Standalone-плеер модуля Music (собственный `<audio>` с очередью, shuffle,
таймером сна, лирикой) был жёстко ограничен проверкой `Lampa.Platform.is('apple')`
в нескольких местах, хотя сам плеер — чистый JS/HTML без платформенных
зависимостей. На Android/Windows пользователи получали только `inner`
(стандартный видео-плеер Lampa) или внешние приложения, без доступа к
удобному интерфейсу очереди.

## Изменения

### 1. `buildMusicPlayerValues()`
Добавлен пункт плеера для всех платформ кроме macOS (там уже есть mpv/iina):

```diff
  if (Lampa.Platform.is('apple') && !Lampa.Platform.macOS()) {
      values.ios = 'iOS';
      values.vlc = 'VLC';
      values.outplayer = 'Outplayer';
      values.nplayer = 'nPlayer';
      values.infuse = 'Infuse';
+ } else if (!Lampa.Platform.macOS()) {
+     values.ios = 'iOS';
  }
```

### 2. `shouldUseStandaloneIosAudio()`
Убрана привязка к Apple — гейт для активации standalone-режима:

```diff
  function shouldUseStandaloneIosAudio() {
-     return Lampa.Platform.is('apple')
-         && currentExternalPlayer() === 'ios'
+     return currentExternalPlayer() === 'ios'
          && getPlaybackMode() === 'audio';
  }
```

### 3. `usesInternalPlaybackFlow()`
Убрана привязка к Apple — иначе на не-Apple платформах плеер `ios`
считался "внешним" и уходил в `musicExternalSchemeUrl`, где для него нет
кейса, из-за чего браузер предлагал открыть трек во внешнем приложении:

```diff
  function usesInternalPlaybackFlow() {
      var player = currentExternalPlayer();
      if (!player) return true;
      if (player === 'inner' || player === 'lampa') return true;
-     if (Lampa.Platform.is('apple') && player === 'ios') return true;
+     if (player === 'ios') return true;
      return false;
  }
```

Это также исправляет прямой доступ к CDN вместо relay — без этого фикса
standalone-плеер на Android получал прямую подписанную ссылку на CDN
(например, `cf-media.sndcdn.com`) вместо `/music/stream`, и браузер обрывал
соединение из-за CORS/несовпадающих заголовков.

### 4. `pickPlaybackSource()`
На реальном iOS WebKit проигрывает HLS нативно в `<audio>`. На Android
Chrome/WebView такой поддержки нет — HLS-манифест просто не воспроизводится
молча. Добавлен фильтр, исключающий HLS-источники для не-Apple платформ,
с фоллбэком на HLS, если другого источника нет:

```diff
  function pickPlaybackSource(sources) {
      if (!Array.isArray(sources) || !sources.length) return null;
+
+     function isHls(s) {
+         var quality = String(s && s.quality || '').toLowerCase();
+         var protocol = String(s && s.protocol || '').toLowerCase();
+         var mime = String(s && s.mime_type || '').toLowerCase();
+         var url = String(s && s.url || '').toLowerCase();
+         return quality.indexOf('hls') !== -1
+             || protocol.indexOf('hls') !== -1
+             || mime.indexOf('mpegurl') !== -1
+             || url.indexOf('.m3u8') !== -1;
+     }
+
      if (!shouldUseStandaloneIosAudio()) {
-         return sources[0];
+         var nonHls = sources.filter(function (s) { return !isHls(s); });
+         return nonHls.length ? nonHls[0] : sources[0];
      }

-     return sources.slice().sort(function (a, b) {
+     var candidates = Lampa.Platform.is('apple')
+         ? sources
+         : sources.filter(function (s) { return !isHls(s); });
+     if (!candidates.length) candidates = sources;
+
+     return candidates.slice().sort(function (a, b) {
          return iosSourceRank(a) - iosSourceRank(b);
      })[0];
  }
```

## Тестирование

- Android (Chrome): standalone-плеер запускается, очередь/shuffle/радио
  работают, воспроизведение через `/music/stream` (не прямой CDN),
  HLS-источники SoundCloud корректно заменяются на progressive.
- iOS: поведение не изменилось (все условия `Lampa.Platform.is('apple')`
  внутри веток остались нетронутыми, включая нативный HLS).
- Windows/desktop (не macOS): то же поведение, что на Android.

## Обратная совместимость

Внутренний id плеера (`'ios'`) не менялся — у пользователей, у которых
он уже был выбран, ничего не сломается. Изменено только условие,
определяющее для *каких платформ* этот пункт показывается в списке.