### PR TITLE
refactor(LampaWeb): add thread safety and legacy Tizen support for widgets

### DIFF
--- a/Modules/LampaWeb/Controllers/ApiController.cs
+++ b/Modules/LampaWeb/Controllers/ApiController.cs
@@ -382,7 +382,7 @@ public class ApiController : BaseController
             {
                 string config = IO.File.ReadAllText($"{publishDirectory}/config.xml");
 
- 
+
                 config = Regex.Replace(config, @"[ \t]*<tizen:service\b[\s\S]*?</tizen:service>\r?\n", string.Empty);
                 config = Regex.Replace(config, @"[ \t]*<tizen:metadata key=""http://samsung\.com/tv/metadata/use\.preview""[^>]*>\r?\n", string.Empty);
 
@@ -783,7 +783,7 @@ public class ApiController : BaseController
 
                     script = FileCache.ReadAllText($"{ModInit.modpath}/plugins/deny.js", "deny.js");
                     if (script.Contains("{country}"))
-                    StatiCacheDisabled = true;
+                        StatiCacheDisabled = true;
 
                     if (script.Contains("{cubMesage}"))
                         script = script.Replace("{cubMesage}", CoreInit.conf.accsdb.authMesage);

--- a/Modules/LampaWeb/Controllers/ApiController.cs
+++ b/Modules/LampaWeb/Controllers/ApiController.cs
@@ -299,83 +299,149 @@ public class ApiController : BaseController
     #endregion
 
     #region Widgets
+    static readonly System.Threading.Lock WidgeLock = new();
+    static readonly System.Threading.Lock IpkLock = new();
+
+    string WidgetHost(string overwritehost)
+    {
+        if (string.IsNullOrWhiteSpace(overwritehost))
+            return host;
+
+        string value = overwritehost.Trim();
+
+        if (!Regex.IsMatch(value, "^https?://", RegexOptions.IgnoreCase))
+            value = "http://" + value;
+
+        if (value.Length > 2048 || !Uri.TryCreate(value, UriKind.Absolute, out Uri uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) ||
+            string.IsNullOrWhiteSpace(uri.Host))
+            throw new ArgumentException("overwritehost: invalid URL");
+
+        return uri.GetLeftPart(UriPartial.Authority);
+    }
+
     [HttpGet, AllowAnonymous]
     [Route("samsung.wgt")]
-    public ActionResult SamsWgt(string overwritehost)
+    public ActionResult SamsWgt(string overwritehost, string tizen)
     {
         if (!ModInit.conf.widgets.samsung)
             return NotFound();
 
-        string cache = $"cache/widgets/samsung/{Shared.Services.Utilities.CrypTo.md5(overwritehost ?? host + "v4")}";
-        string wgt = $"{cache}.wgt";
+        SetHeadersNoCache();
 
-        if (IO.File.Exists(wgt))
+        try
+        {
+            string replaceHost = WidgetHost(overwritehost);
+            bool legacy = double.TryParse(tizen, System.Globalization.CultureInfo.InvariantCulture, out double tizenver) && tizenver <= 3;
+
+            string cache = $"cache/widgets/samsung/{Shared.Services.Utilities.CrypTo.md5($"{replaceHost}|v5|{legacy}")}";
+            string wgt = $"{cache}.wgt";
+
+            lock (WidgeLock)
+            {
+                if (!IO.File.Exists(wgt))
+                    BuildSamsWgt(cache, wgt, replaceHost, legacy);
+            }
+
+            Response.Headers["Content-Disposition"] = "attachment; filename=\"samsung.wgt\"";
             return File(IO.File.OpenRead(wgt), "application/octet-stream");
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "{Class} {CatchId}", nameof(ApiController), "id_samsung_wgt");
+            return Content($"samsung.wgt build failed: {ex.Message}", "text/plain; charset=utf-8");
+        }
+    }
 
+    void BuildSamsWgt(string cache, string wgt, string replaceHost, bool legacy)
+    {
         var widgetDirectory = $"{ModInit.modpath}/widgets/samsung";
         var publishDirectory = $"{cache}/publish";
 
-        IO.Directory.CreateDirectory(publishDirectory);
-
-        foreach (string inFilePath in IO.Directory.GetFiles(widgetDirectory, "*", IO.SearchOption.AllDirectories))
+        try
         {
-            string outFile = inFilePath.Replace(widgetDirectory, publishDirectory);
-            IO.Directory.CreateDirectory(IO.Path.GetDirectoryName(outFile));
-            IO.File.Copy(inFilePath, outFile, true);
-        }
+            IO.Directory.CreateDirectory(publishDirectory);
 
-        string index = IO.File.ReadAllText($"{publishDirectory}/index.html");
-        IO.File.WriteAllText($"{publishDirectory}/index.html", index.Replace("{localhost}", overwritehost ?? host));
-
-        string loader = IO.File.ReadAllText($"{publishDirectory}/loader.js");
-        IO.File.WriteAllText($"{publishDirectory}/loader.js", loader.Replace("{localhost}", overwritehost ?? host));
-
-        string app = IO.File.ReadAllText($"{publishDirectory}/app.js");
-        IO.File.WriteAllText($"{publishDirectory}/app.js", app.Replace("{localhost}", overwritehost ?? host));
-
-        string gethash(string file)
-        {
-            using (var sha = System.Security.Cryptography.SHA512.Create())
+            foreach (string inFilePath in IO.Directory.GetFiles(widgetDirectory, "*", IO.SearchOption.AllDirectories))
             {
-                return Convert.ToBase64String(sha.ComputeHash(IO.File.ReadAllBytes(file)));
+                string outFile = inFilePath.Replace(widgetDirectory, publishDirectory);
+                IO.Directory.CreateDirectory(IO.Path.GetDirectoryName(outFile));
+                IO.File.Copy(inFilePath, outFile, true);
             }
+
+            string index = IO.File.ReadAllText($"{publishDirectory}/index.html");
+            IO.File.WriteAllText($"{publishDirectory}/index.html", index.Replace("{localhost}", replaceHost));
+
+            string loader = IO.File.ReadAllText($"{publishDirectory}/loader.js");
+            IO.File.WriteAllText($"{publishDirectory}/loader.js", loader.Replace("{localhost}", replaceHost));
+
+            string app = IO.File.ReadAllText($"{publishDirectory}/app.js");
+            IO.File.WriteAllText($"{publishDirectory}/app.js", app.Replace("{localhost}", replaceHost));
+
+            if (legacy)
+            {
+                string config = IO.File.ReadAllText($"{publishDirectory}/config.xml");
+
+ 
+                config = Regex.Replace(config, @"[ \t]*<tizen:service\b[\s\S]*?</tizen:service>\r?\n", string.Empty);
+                config = Regex.Replace(config, @"[ \t]*<tizen:metadata key=""http://samsung\.com/tv/metadata/use\.preview""[^>]*>\r?\n", string.Empty);
+
+                if (config.Contains("tizen:service") || config.Contains("use.preview"))
+                    throw new InvalidOperationException("legacy tizen: не удалось вырезать tizen:service из config.xml");
+
+                IO.File.WriteAllText($"{publishDirectory}/config.xml", config);
+            }
+
+            string gethash(string file)
+            {
+                using (var sha = System.Security.Cryptography.SHA512.Create())
+                {
+                    return Convert.ToBase64String(sha.ComputeHash(IO.File.ReadAllBytes(file)));
+                }
+            }
+
+            string indexhashsha512 = gethash($"{publishDirectory}/index.html");
+            string loaderhashsha512 = gethash($"{publishDirectory}/loader.js");
+            string apphashsha512 = gethash($"{publishDirectory}/app.js");
+            string confighashsha512 = gethash($"{publishDirectory}/config.xml");
+            string iconhashsha512 = gethash($"{publishDirectory}/icon.png");
+            string logohashsha512 = gethash($"{publishDirectory}/logo_appname_fg.png");
+
+            string author_sigxml = IO.File.ReadAllText($"{widgetDirectory}/author-signature.xml");
+            author_sigxml = author_sigxml
+                .Replace("loaderhashsha512", loaderhashsha512)
+                .Replace("apphashsha512", apphashsha512)
+                .Replace("iconhashsha512", iconhashsha512)
+                .Replace("logohashsha512", logohashsha512)
+                .Replace("confighashsha512", confighashsha512)
+                .Replace("indexhashsha512", indexhashsha512);
+
+            IO.File.WriteAllText($"{publishDirectory}/author-signature.xml", author_sigxml);
+
+            string authorsignaturehashsha512 = gethash($"{publishDirectory}/author-signature.xml");
+            string sigxml1 = IO.File.ReadAllText($"{publishDirectory}/signature1.xml");
+            sigxml1 = sigxml1
+                .Replace("loaderhashsha512", loaderhashsha512)
+                .Replace("apphashsha512", apphashsha512)
+                .Replace("confighashsha512", confighashsha512)
+                .Replace("authorsignaturehashsha512", authorsignaturehashsha512)
+                .Replace("iconhashsha512", iconhashsha512)
+                .Replace("logohashsha512", logohashsha512)
+                .Replace("indexhashsha512", indexhashsha512);
+
+            IO.File.WriteAllText($"{publishDirectory}/signature1.xml", sigxml1);
+
+            IO.Compression.ZipFile.CreateFromDirectory(publishDirectory, $"{wgt}.tmp");
+            IO.File.Move($"{wgt}.tmp", wgt, true);
         }
+        finally
+        {
+            if (IO.Directory.Exists(cache))
+                IO.Directory.Delete(cache, true);
 
-        string indexhashsha512 = gethash($"{publishDirectory}/index.html");
-        string loaderhashsha512 = gethash($"{publishDirectory}/loader.js");
-        string apphashsha512 = gethash($"{publishDirectory}/app.js");
-        string confighashsha512 = gethash($"{publishDirectory}/config.xml");
-        string iconhashsha512 = gethash($"{publishDirectory}/icon.png");
-        string logohashsha512 = gethash($"{publishDirectory}/logo_appname_fg.png");
-
-        string author_sigxml = IO.File.ReadAllText($"{widgetDirectory}/author-signature.xml");
-        author_sigxml = author_sigxml
-            .Replace("loaderhashsha512", loaderhashsha512)
-            .Replace("apphashsha512", apphashsha512)
-            .Replace("iconhashsha512", iconhashsha512)
-            .Replace("logohashsha512", logohashsha512)
-            .Replace("confighashsha512", confighashsha512)
-            .Replace("indexhashsha512", indexhashsha512);
-
-        IO.File.WriteAllText($"{publishDirectory}/author-signature.xml", author_sigxml);
-
-        string authorsignaturehashsha512 = gethash($"{publishDirectory}/author-signature.xml");
-        string sigxml1 = IO.File.ReadAllText($"{publishDirectory}/signature1.xml");
-        sigxml1 = sigxml1
-            .Replace("loaderhashsha512", loaderhashsha512)
-            .Replace("apphashsha512", apphashsha512)
-            .Replace("confighashsha512", confighashsha512)
-            .Replace("authorsignaturehashsha512", authorsignaturehashsha512)
-            .Replace("iconhashsha512", iconhashsha512)
-            .Replace("logohashsha512", logohashsha512)
-            .Replace("indexhashsha512", indexhashsha512);
-
-        IO.File.WriteAllText($"{publishDirectory}/signature1.xml", sigxml1);
-        IO.Compression.ZipFile.CreateFromDirectory(publishDirectory, wgt);
-
-        IO.Directory.Delete(cache, true);
-
-        return File(IO.File.OpenRead(wgt), "application/octet-stream");
+            if (IO.File.Exists($"{wgt}.tmp"))
+                IO.File.Delete($"{wgt}.tmp");
+        }
     }
 
     [HttpGet]
@@ -386,20 +452,45 @@ public class ApiController : BaseController
         if (!ModInit.conf.widgets.lg)
             return NotFound();
 
-        string cache = $"cache/widgets/lg/{Shared.Services.Utilities.CrypTo.md5(overwritehost ?? host + "v01")}";
-        string ipk = $"{cache}.ipk";
+        SetHeadersNoCache();
 
-        if (IO.File.Exists(ipk))
+        try
+        {
+            string replaceHost = WidgetHost(overwritehost);
+
+            string cache = $"cache/widgets/lg/{Shared.Services.Utilities.CrypTo.md5($"{replaceHost}|v02")}";
+            string ipk = $"{cache}.ipk";
+
+            if (!IO.File.Exists(ipk))
+            {
+                var widgetDirectory = $"{ModInit.modpath}/widgets/lg";
+
+                if (!IO.Directory.Exists(widgetDirectory) ||
+                    !IO.Directory.Exists($"{widgetDirectory}/app") ||
+                    !IO.File.Exists($"{widgetDirectory}/service.tar.gz") ||
+                    !IO.File.Exists($"{widgetDirectory}/control/control"))
+                    return NotFound();
+
+                lock (IpkLock)
+                {
+                    if (!IO.File.Exists(ipk))
+                        BuildLgIpk(ipk, replaceHost);
+                }
+            }
+
+            Response.Headers["Content-Disposition"] = "attachment; filename=\"lg.ipk\"";
             return File(IO.File.OpenRead(ipk), "application/octet-stream");
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "{Class} {CatchId}", nameof(ApiController), "id_lg_ipk");
+            return Content($"lg.ipk build failed: {ex.Message}", "text/plain; charset=utf-8");
+        }
+    }
 
+    void BuildLgIpk(string ipk, string replaceHost)
+    {
         var widgetDirectory = $"{ModInit.modpath}/widgets/lg";
-        if (!IO.Directory.Exists(widgetDirectory))
-            return NotFound();
-
-        if (!IO.Directory.Exists($"{widgetDirectory}/app") ||
-            !IO.File.Exists($"{widgetDirectory}/service.tar.gz") ||
-            !IO.File.Exists($"{widgetDirectory}/control/control"))
-            return NotFound();
 
         const string appId = "com.lampac.tv";
         const string serviceId = appId + ".worker";
@@ -407,7 +498,6 @@ public class ApiController : BaseController
         string appSource = $"{widgetDirectory}/app";
         string serviceArchive = $"{widgetDirectory}/service.tar.gz";
         string controlSource = $"{widgetDirectory}/control";
-        string replaceHost = overwritehost ?? host;
 
         #region packageinfo.json (mandatory for webOS)
         string appVersion = "1.0.0";
@@ -511,16 +601,26 @@ public class ApiController : BaseController
 
         IO.Directory.CreateDirectory(IO.Path.GetDirectoryName(ipk));
 
-        using (var stream = IO.File.Create(ipk))
-        using (var writer = new IO.BinaryWriter(stream, Encoding.ASCII, leaveOpen: false))
+        try
         {
-            writer.Write(Encoding.ASCII.GetBytes("!<arch>\n"));
-            WriteArFile(writer, "debian-binary", debianBinary);
-            WriteArFile(writer, "control.tar.gz", controlTarGz);
-            WriteArFile(writer, "data.tar.gz", dataTarGz);
+            using (var stream = IO.File.Create($"{ipk}.tmp"))
+            using (var writer = new IO.BinaryWriter(stream, Encoding.ASCII, leaveOpen: false))
+            {
+                writer.Write(Encoding.ASCII.GetBytes("!<arch>\n"));
+                WriteArFile(writer, "debian-binary", debianBinary);
+                WriteArFile(writer, "control.tar.gz", controlTarGz);
+                WriteArFile(writer, "data.tar.gz", dataTarGz);
+            }
+
+            IO.File.Move($"{ipk}.tmp", ipk, true);
+        }
+        finally
+        {
+            if (IO.File.Exists($"{ipk}.tmp"))
+                IO.File.Delete($"{ipk}.tmp");
         }
 
-        return File(IO.File.OpenRead(ipk), "application/octet-stream");
+        return;
 
         static byte[] BuildTarGz(Action<TarWriter> write)
         {
@@ -683,7 +783,7 @@ public class ApiController : BaseController
 
                     script = FileCache.ReadAllText($"{ModInit.modpath}/plugins/deny.js", "deny.js");
                     if (script.Contains("{country}"))
-                        StatiCacheDisabled = true;
+                    StatiCacheDisabled = true;
 
                     if (script.Contains("{cubMesage}"))
                         script = script.Replace("{cubMesage}", CoreInit.conf.accsdb.authMesage);

--- a/Modules/LampaWeb/README.md
+++ b/Modules/LampaWeb/README.md
@@ -17,7 +17,7 @@
 | `/testaccsdb` | Проверка доступа accsdb (GET/POST); см. также **`EventListener.Accsdb`** в `ModInit`. |
 | `/app.min.js`, `/{type}/app.min.js` | Сборка минифицированного приложения. |
 | `/css/app.css` | Стили. |
-| `msx/start.json`, `samsung.wgt`, `lg.ipk` | Специфичные для ТВ пакеты (MSX, Samsung Tizen, LG webOS). |
+| `msx/start.json`, `samsung.wgt`, `lg.ipk` | Специфичные для ТВ пакеты (MSX, Samsung Tizen, LG webOS). Для `samsung.wgt` параметр `?tizen=3` убирает `tizen:service` — без этого виджет не ставится на Tizen 3.0 и ниже. |
 | `/lampainit.js` | Инициализация клиента (подстановки плагинов, **deny.js**, токены). |
 | `/on.js`, `/on/js/{token}`, `/on/h/{token}`, `/on/{token}` | Режим онлайн-плагина. |
 | `/dorama.js`, `/dorama/js/{token}` | Отдельный Lampa-плагин пункта **«Дорамы»** и источника `lampac_dorama`. |

--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ cd publish && dotnet Core.dll
 | `GET` | `/gst.js` | GStreamer: плагин Lampa для серверного транскодинга |
 | `GET` | `/gst/add` | GStreamer: создать задачу транскодинга |
 | `GET` | `/gst/{id}/master.m3u8` | GStreamer: HLS-плейлист задачи |
-| `GET` | `/samsung.wgt` | LampaWeb: виджет Samsung Tizen |
+| `GET` | `/samsung.wgt` | LampaWeb: виджет Samsung Tizen (`?tizen=3` — сборка без фонового сервиса для Tizen 3.0 и ниже) |
 | `GET` | `/lg.ipk` | LampaWeb: виджет LG webOS |
 | `GET` | `/tg-notify.js` | Tg-notify.bot: плагин Telegram-подписок |
 | `GET` | `/api/tg/voices` | Tg-notify.bot: список озвучек (Mirage + Collaps) |


### PR DESCRIPTION
Refactored `SamsWgt` and `LgIpk` methods to include thread-safe operations using `WidgeLock` and `IpkLock`. Added `WidgetHost` for URL validation and introduced support for legacy Tizen (<= 3.0) by removing `tizen:service`. Enhanced error handling with `Serilog` logging. Updated README.md to document new parameters and clarify endpoint behavior.