### PR TITLE
fix(PlaywrightCore): detect chromium on linux-arm64

### DIFF
--- a/Shared/PlaywrightCore/Chromium.cs
+++ b/Shared/PlaywrightCore/Chromium.cs
@@ -96,6 +96,7 @@ public class Chromium : PlaywrightBase, IDisposable
                     {
                         case Architecture.X86:
                         case Architecture.X64:
+                        case Architecture.Arm64:
                             {
                                 executablePath = File.Exists(".playwright/chrome-linux/chrome")
                                     ? ".playwright/chrome-linux/chrome"
@@ -103,7 +104,7 @@ public class Chromium : PlaywrightBase, IDisposable
                                 break;
                             }
                         default:
-                            Console.WriteLine("PlaywChromiumright: Architecture unknown");
+                            Console.WriteLine("Chromium: Architecture unknown");
                             return;
                     }
                 }


### PR DESCRIPTION
В официальном arm64-образе Chromium не запускается, если в `init.conf` не прописан `executablePath` руками. С конфигом `"chromium": { "enable": true }` в лог падает `PlaywChromiumright: Architecture unknown`, и `CreateAsync` выходит.

Как повторить: Hetzner ARM (aarch64, 4 ядра), образ `ghcr.io/lampac-nextgen/lampac:1.48.4`, в секции `chromium` только `enable`. В логе:

```
Playwright: Initialization
PlaywChromiumright: Architecture unknown
```

Почему так. В Linux-ветке автоопределения пути ([Chromium.cs#L93-L108](https://github.com/lampac-nextgen/lampac/blob/49e7589/Shared/PlaywrightCore/Chromium.cs#L93-L108)) разобраны только `Architecture.X86` и `Architecture.X64`, `Arm64` уезжает в `default`. Похоже на пропуск, а не на решение: в macOS-ветке этого же файла `Arm64` есть, в [Firefox.cs#L71-L84](https://github.com/lampac-nextgen/lampac/blob/49e7589/Shared/PlaywrightCore/Firefox.cs#L71-L84) в Linux-ветке тоже, да и Dockerfile ставит `google-chrome-stable` под arm64 и делает симлинк `/usr/bin/chromium` ([Dockerfile#L118-L125](https://github.com/lampac-nextgen/lampac/blob/49e7589/Dockerfile#L118-L125)).

Что в патче. Один файл, две правки. `Architecture.Arm64` добавлен в Linux-ветку рядом с x64, приоритет `.playwright/chrome-linux/chrome` с откатом на `/usr/bin/chromium` остался прежний. И опечатка в сообщении: было `PlaywChromiumright`, стало `Chromium`.

`Firefox.cs` не трогал — `Arm64` в Linux-ветке там уже разобран.

В первой версии сюда же было приделано чтение `CHROMIUM_PATH` и `CHROMIUM_FLAGS`. Убрал: у той части другой радиус поражения, она включает `--no-sandbox` всем подряд, включая bare-metal, и отменить это через `init.conf` нельзя. Вынес обсуждение в #173.

Проверял двумя способами. На той же машине дописал в конфиг `"executablePath": "/usr/bin/chromium"` — то есть ровно тот путь, который патч выбирает сам, — и браузер поднялся: `Chromium: v152.0.7977.64 / headless / True`, RSS контейнера вырос с 259 до 842 МБ. Плюс `dotnet build Shared/Shared.csproj -c Release` на .NET 10 SDK: 0 warnings, 0 errors. Образ из самого патча на arm64 не пересобирал.

