### PR TITLE
fix(Accsdb): keep accounts on init.conf hot-reload

### DIFF
--- a/Shared/CoreInit.cs
+++ b/Shared/CoreInit.cs
@@ -168,27 +168,9 @@ public class CoreInit
         if (_tempConf == null)
             throw new Exception("Failed to deserialize init.conf");
 
-        conf = _tempConf;
+        _tempConf.accsdb.MergeAccounts();
 
-        if (conf.accsdb.accounts != null)
-        {
-            foreach (var u in conf.accsdb.accounts)
-            {
-                if (conf.accsdb.findUser(u.Key) is AccsUser user)
-                {
-                    if (u.Value > user.expires)
-                        user.expires = u.Value;
-                }
-                else
-                {
-                    conf.accsdb.users.Add(new AccsUser()
-                    {
-                        id = u.Key.ToLowerAndTrim(),
-                        expires = u.Value
-                    });
-                }
-            }
-        }
+        conf = _tempConf;
 
         PosterApi.Initialization(conf.omdbapi_key, conf.posterApi);
     }
@@ -219,25 +201,7 @@ public class CoreInit
                             }
                         });
 
-                        if (conf.accsdb.accounts != null)
-                        {
-                            foreach (var u in conf.accsdb.accounts)
-                            {
-                                if (conf.accsdb.findUser(u.Key) is AccsUser user)
-                                {
-                                    if (u.Value > user.expires)
-                                        user.expires = u.Value;
-                                }
-                                else
-                                {
-                                    conf.accsdb.users.Add(new AccsUser()
-                                    {
-                                        id = u.Key.ToLowerAndTrim(),
-                                        expires = u.Value
-                                    });
-                                }
-                            }
-                        }
+                        conf.accsdb.MergeAccounts();
 
                         PosterApi.Initialization(conf.omdbapi_key, conf.posterApi);
                     }

--- a/Shared/Models/AppConf/AccsConf.cs
+++ b/Shared/Models/AppConf/AccsConf.cs
@@ -57,6 +57,9 @@ public class AccsConf
 
             foreach (AccsUser u in users)
             {
+                if (u == null)
+                    continue;
+
                 if (!string.IsNullOrEmpty(u.id))
                     _users[u.id.ToLowerAndTrim()] = u;
 
@@ -73,6 +76,35 @@ public class AccsConf
             _searchUsers = _users;
         }
         catch { }
+    }
+
+    public void MergeAccounts()
+    {
+        if (accounts == null || accounts.Count == 0)
+            return;
+
+        users ??= new ConcurrentBag<AccsUser>();
+
+        RefreshUsers();
+
+        foreach (var account in accounts)
+        {
+            if (findUser(account.Key) is AccsUser user)
+            {
+                if (account.Value > user.expires)
+                    user.expires = account.Value;
+            }
+            else
+            {
+                users.Add(new AccsUser()
+                {
+                    id = account.Key.ToLowerAndTrim(),
+                    expires = account.Value
+                });
+            }
+        }
+
+        RefreshUsers();
     }
 
     public AccsUser findUser(HttpContext httpContext, out string uid)


### PR DESCRIPTION
На работающем сервере любая правка init.conf выкидывает из accsdb все аккаунты, кроме тех, что добавлены этой же правкой. После хот-релоада защищённые запросы потерянных аккаунтов получают `{"accsdb":true,"msg":"Добавьте <пароль> в init.conf"}`, и лечится это только рестартом процесса. Локальные и анонимные запросы, а также пути под `whitepattern` и `white_uids` проверку обходят ([Accsdb.cs#L101-L114](https://github.com/lampac-nextgen/lampac/blob/49e7589/Core/Middlewares/Accsdb.cs#L101-L114)), поэтому снаружи это выглядит как «отвалилась часть клиентов».

Как повторить: включить `accsdb.enable` с непустым `accounts`, дождаться старта, поменять в init.conf любой ключ и сохранить. Через секунду watcher перечитает конфиг, и аккаунтов в `users` не будет.

Почему так. Индекс `_searchUsers` в [AccsConf.cs#L44](https://github.com/lampac-nextgen/lampac/blob/49e7589/Shared/Models/AppConf/AccsConf.cs#L44) объявлен `static`, то есть он общий для всех экземпляров `AccsConf` и живёт дольше самого конфига. В `updateConf()` ([CoreInit.cs#L171-L191](https://github.com/lampac-nextgen/lampac/blob/49e7589/Shared/CoreInit.cs#L171-L191)) сначала публикуется новый `conf` с пустым `users`, а потом для каждой записи из `accounts` зовётся `findUser()`, который читает индекс от предыдущего конфига. Аккаунт, живший в конфиге и до правки, там находится, код уходит в ветку `user.expires = ...` и правит объект из старого экземпляра, а в новый `users` не попадает. Ключ, добавленный этой же правкой, в старом индексе отсутствует и в `users` как раз попадёт, так что после релоада в списке остаются только свежедобавленные аккаунты. Дальше watcher вызывает `RefreshUsers()` ([CoreInit.cs#L113](https://github.com/lampac-nextgen/lampac/blob/49e7589/Shared/CoreInit.cs#L113)), тот перестраивает индекс по обрезанному `users`, и `findUser` перестаёт находить всё остальное. На первом старте индекс ещё null, поэтому там всё отрабатывает правильно.

Что в патче. Слияние `accounts` в `users` переехало из `CoreInit` в `AccsConf.MergeAccounts()`; один и тот же блок был скопирован в `updateConf()` и `updateYamlConf()`. Перед слиянием индекс перестраивается по текущему `users`, так что чужие данные в него уже не попадают. Заодно уходит дубль в yaml-ветке: раньше при наличии init.yaml аккаунты из init.conf добавлялись в `users` по второму разу.

Порядок в `updateConf()`. Слияние теперь идёт до `conf = _tempConf`, а не после: наружу публикуется конфиг, в котором аккаунты уже на месте. Раньше между присваиванием и слиянием был промежуток, где живые запросы видели новый конфиг с пустым `users`, а `findUser(HttpContext, out string)` на пустой коллекции сразу возвращает null ([AccsConf.cs#L78-L83](https://github.com/lampac-nextgen/lampac/blob/49e7589/Shared/Models/AppConf/AccsConf.cs#L78-L83)). Цена нового порядка в том, что `MergeAccounts()` внутри зовёт `RefreshUsers()`, поэтому статический индекс какое-то время опережает `conf`: запрос, попавший в этот промежуток, проверится по старому экземпляру, но по новому индексу. Размен неравноценный: старое окно гарантированно отклоняло всё, новое в худшем случае пропустит аккаунт, только что удалённый из конфига.

`updateYamlConf()` оставлен как есть. Он не строит временный объект, а через `JsonConvert.PopulateObject` пишет прямо в уже опубликованный `conf` ([CoreInit.cs#L213](https://github.com/lampac-nextgen/lampac/blob/49e7589/Shared/CoreInit.cs#L213)), так что сделать его атомарным можно только вместе с перекройкой всей связки updateConf/updateYamlConf/watcher — это заметно больше, чем правка бага. После патча окно там в любом случае сузилось: аккаунты из init.conf уже слиты в `updateConf()`, а `MergeAccounts()` в yaml-ветке добирает только то, что объявлено в самом init.yaml.

Устойчивость к мусору в конфиге. `RefreshUsers()` глушит исключения через `catch { }`, поэтому одного `null` в массиве `users` хватало, чтобы перестройка индекса свалилась на `u.id` и `_searchUsers` молча остался прежним, а дальше повторялась та же история с чужим индексом. Теперь `RefreshUsers()` пропускает пустые элементы, а `MergeAccounts()` создаёт коллекцию, если `users` пришёл `null` (иначе `users.Add(...)` бросал NRE уже после публикации конфига, и watcher уходил в бесконечный цикл падений раз в секунду). Две строки, обе внутри существующих проверок.

Про `_searchUsers`. Поле оставлено статическим, чтобы не расширять патч: перевод его в поле экземпляра — отдельная правка со своими последствиями для `UpdateUsersDb()`. В предыдущей версии описания я объяснял это тем, что в окне между публикацией `conf` и первым `RefreshUsers()` статическое поле отдаёт старый, но валидный индекс. Это верно только для прямого `findUser(StringValues)`; основной HTTP-overload сначала смотрит на `users` нового экземпляра и на пустой коллекции возвращает null, не заглядывая в индекс. Гонок вокруг пары `conf`/`_searchUsers` патч не убирает, они были до него и остаются после: watcher крутится в ThreadPool раз в секунду ([CoreInit.cs#L95-L99](https://github.com/lampac-nextgen/lampac/blob/49e7589/Shared/CoreInit.cs#L95-L99)), параллельно раз в секунду ходит `UpdateUsersDb()` из [Program.cs#L298](https://github.com/lampac-nextgen/lampac/blob/49e7589/Core/Program.cs#L298) и правит объекты из того же индекса, ни блокировок, ни `volatile` вокруг `conf` нет. Закрывается только конкретное окно в `updateConf()`, где опубликованный конфиг гарантированно ехал без аккаунтов.

Проверял на .NET 10 SDK: собрал `Shared` и `Core` (0 warnings, 0 errors) и прогнал харнесс, который поднимает `CoreInit` во временной папке, пишет init.conf с одним аккаунтом и потом трижды его правит. До патча: после правки ключа `users=0, findUser=False`; с `"users":[null]` — `findUser=False`; с `"users":null` — reload падает на NRE и `users` остаётся null. После патча во всех трёх случаях `findUser=True`.
