### PR TITLE
chore: remove unread CHROMIUM_PATH and CHROMIUM_FLAGS env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,9 +86,7 @@ ENV DOTNET_ROOT=/usr/share/dotnet \
     PATH="${PATH}:/usr/share/dotnet" \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
-    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
-    CHROMIUM_PATH=/usr/bin/google-chrome-stable \
-    CHROMIUM_FLAGS="--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage"
+    DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 WORKDIR /lampac
 EXPOSE 9118

--- a/docs/config.html
+++ b/docs/config.html
@@ -629,7 +629,9 @@
   <span class="hl-key">"chromium"</span>: {
     <span class="hl-key">"enable"</span>:  <span class="hl-bool">false</span>,
     <span class="hl-key">"count"</span>:   <span class="hl-val">1</span>,      <span class="hl-comment">// количество экземпляров в пуле</span>
-    <span class="hl-key">"restart"</span>: <span class="hl-val">3600</span>   <span class="hl-comment">// перезапуск каждые N секунд</span>
+    <span class="hl-key">"restart"</span>: <span class="hl-val">3600</span>,  <span class="hl-comment">// перезапуск каждые N секунд</span>
+    <span class="hl-key">"executablePath"</span>: <span class="hl-string">"/usr/bin/chromium"</span>,  <span class="hl-comment">// путь к бинарнику, если автоопределение не подошло</span>
+    <span class="hl-key">"Args"</span>: [<span class="hl-string">"--no-sandbox"</span>]  <span class="hl-comment">// флаги командной строки браузера</span>
   },
   <span class="hl-key">"firefox"</span>: {
     <span class="hl-key">"enable"</span>: <span class="hl-bool">false</span>,
@@ -639,7 +641,9 @@
         </div>
         <div class="callout callout-warn"><span class="callout-icon">⚠️</span>
           <p>Playwright требует установленного Chromium/Firefox. В Docker-образе зависимости включены. Для нативной
-            установки — дополнительная команда <code>playwright install chromium</code>.</p>
+            установки — дополнительная команда <code>playwright install chromium</code>. Путь к бинарнику и флаги
+            запуска задаются только через <code>executablePath</code> и <code>Args</code>: переменные окружения код не
+            читает.</p>
         </div>
       </div>
 

--- a/install.sh
+++ b/install.sh
@@ -943,8 +943,6 @@ Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$D
 Environment=DOTNET_RUNNING_IN_CONTAINER=false
 Environment=DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 Environment=DOTNET_CLI_TELEMETRY_OPTOUT=1
-Environment=CHROMIUM_PATH=/usr/bin/google-chrome-stable
-Environment="CHROMIUM_FLAGS=--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage"
 ExecStart=$DOTNET_INSTALL_DIR/dotnet $INSTALL_ROOT/Core.dll
 Restart=on-failure
 RestartSec=10


### PR DESCRIPTION
Closes #173, вариант со снятием переменных.

`CHROMIUM_PATH` и `CHROMIUM_FLAGS` уходят из Dockerfile и из systemd-юнита в install.sh. Код их не читает: в `LaunchAsync` передаётся только `init.Args` из конфига.

Флаги при этом никуда не переезжают, и это осознанно. Прогнал официальный `ghcr.io/lampac-nextgen/lampac:1.48.5` на Hetzner ARM вообще без своего init.conf — то есть с дефолтным `chromium.enable = true` и единственным `--disable-blink-features=AutomationControlled`:

```
Chromium: v152.0.7977.64 / headless / True
```

Дальше пять `/api/chromium/ping` подряд и шесть параллельных `/api/chromium/iframe` на внешний сайт: все ответили, процессов Chrome 11, RSS контейнера 756 МБ, `/dev/shm` — дефолтные 64 МБ. Ни `--no-sandbox`, ни `--disable-dev-shm-usage` не понадобились. Положить их в дефолтный init.conf — значит выключить sandbox тем, у кого он и так работает.

Выбор бинарника тоже не меняется: переменная указывала на `/usr/bin/google-chrome-stable`, а автоопределение берёт `.playwright/chrome-linux/chrome` с откатом на `/usr/bin/chromium` — симлинк туда делают и Dockerfile, и install.sh.

В `docs/config.html` добавил в пример секции `chromium` поля `executablePath` и `Args` плюс строку о том, что путь и флаги задаются только конфигом.

`shm_size: 1024mb` в docker-compose.yaml не трогал.
