### PR TITLE
feat(LampaWeb): implement LampaPluginBuilder for plugin management

### DIFF
--- a/Modules/LampaWeb/Controllers/ApiController.cs
+++ b/Modules/LampaWeb/Controllers/ApiController.cs
@@ -697,64 +697,9 @@ public class ApiController : BaseController
             sb = sb.Append(lampainitjs);
 
             #region plugins
-            List<LampaPlugin> plugins = new(20);
-
-            if (ModInit.conf.initPlugins.dlna)
-                plugins.Add(new("{localhost}/dlna.js", 1, "DLNA", "lampac"));
-
-            if (ModInit.conf.initPlugins.tracks)
-                plugins.Add(new("{localhost}/tracks.js", 1, "Tracks.js", "lampac"));
-
-            if (ModInit.conf.initPlugins.transcoding)
-                plugins.Add(new("{localhost}/transcoding.js", 1, "Transcoding video", "lampac"));
-
-            if (ModInit.conf.initPlugins.tmdbProxy)
-                plugins.Add(new("{localhost}/tmdbproxy.js", 1, "TMDB Proxy", "lampac"));
-
-            if (ModInit.conf.initPlugins.cubProxy)
-                plugins.Add(new("{localhost}/cubproxy.js", 1, "CUB Proxy", "lampac"));
-
-            if (ModInit.conf.initPlugins.online)
-                plugins.Add(new("{localhost}/online.js", 1, "Онлайн", "lampac"));
-
-            if (ModInit.conf.initPlugins.watch_together)
-                plugins.Add(new("{localhost}/watchtogether.js", 1, "Watch Together", "lampac"));
-
-            if (ModInit.conf.initPlugins.catalog)
-                plugins.Add(new("{localhost}/catalog.js", 1, "Альтернативные источники каталога", "lampac"));
-
-            if (ModInit.conf.initPlugins.dorama)
-                plugins.Add(new("{localhost}/dorama.js", 1, "Дорамы", "lampac"));
-
-            if (ModInit.conf.initPlugins.sisi)
-            {
-                plugins.Add(new("{localhost}/sisi.js", 1, "Клубничка", "lampac"));
-                plugins.Add(new("{localhost}/startpage.js", 1, "Стартовая страница", "lampac"));
-            }
-
-            if (ModInit.conf.initPlugins.sync)
-                plugins.Add(new("{localhost}/sync.js", 1, "Синхронизация", "lampac"));
-
-            if (ModInit.conf.initPlugins.timecode)
-                plugins.Add(new("{localhost}/timecode.js", 1, "Синхронизация тайм-кодов", "lampac"));
-
-            if (ModInit.conf.initPlugins.bookmark)
-                plugins.Add(new("{localhost}/bookmark.js", 1, "Синхронизация закладок", "lampac"));
-
-            if (ModInit.conf.initPlugins.torrserver)
-                plugins.Add(new("{localhost}/ts.js", 1, "TorrServer", "lampac"));
-
-            if (ModInit.conf.initPlugins.backup)
-                plugins.Add(new("{localhost}/backup.js", 1, "Backup", "lampac"));
-
-            if (ModInit.conf.customPlugins != null)
-            {
-                foreach (var p in ModInit.conf.customPlugins)
-                {
-                    if (p.status == 1)
-                        plugins.Add(p);
-                }
-            }
+            var plugins = LampaPluginBuilder.BuildInitPlugins(
+                ModInit.conf.initPlugins,
+                ModInit.conf.customPlugins);
 
             sb = sb.Replace("{initiale}", JsonConvert.SerializeObject(plugins));
             #endregion
@@ -885,73 +830,11 @@ public class ApiController : BaseController
             if (adult && HttpContext.Request.Path.Value.StartsWith("/on/h/"))
                 adult = false;
 
-            var plugins = new List<string>(15);
-
-            void send(string name, bool worktoken)
-            {
-                if (worktoken && !string.IsNullOrEmpty(token))
-                {
-                    plugins.Add($"\"{{localhost}}/{name}/js/{HttpUtility.UrlEncode(token)}\"");
-                }
-                else
-                {
-                    plugins.Add($"\"{{localhost}}/{name}.js\"");
-                }
-            }
-
-            if (ModInit.conf.initPlugins.dlna)
-                send("dlna", true);
-
-            if (ModInit.conf.initPlugins.tracks)
-                send("tracks", true);
-
-            if (ModInit.conf.initPlugins.transcoding)
-                send("transcoding", true);
-
-            if (ModInit.conf.initPlugins.tmdbProxy)
-                send("tmdbproxy", true);
-
-            if (ModInit.conf.initPlugins.cubProxy)
-                send("cubproxy", true);
-
-            if (ModInit.conf.initPlugins.dorama)
-                send("dorama", true);
-
-            if (ModInit.conf.initPlugins.online)
-                send("online", true);
-
-            if (ModInit.conf.initPlugins.watch_together)
-                send("watchtogether", false);
-
-            if (adult && ModInit.conf.initPlugins.sisi)
-            {
-                send("sisi", true);
-                send("startpage", false);
-            }
-
-            if (ModInit.conf.initPlugins.sync)
-                send("sync", true);
-
-            if (ModInit.conf.initPlugins.timecode)
-                send("timecode", true);
-
-            if (ModInit.conf.initPlugins.bookmark)
-                send("bookmark", true);
-
-            if (ModInit.conf.initPlugins.torrserver)
-                send("ts", true);
-
-            if (ModInit.conf.initPlugins.backup)
-                send("backup", true);
-
-            if (ModInit.conf.customPlugins != null)
-            {
-                foreach (var p in ModInit.conf.customPlugins)
-                {
-                    if (p.status == 1)
-                        plugins.Add($"\"{p.url}\"");
-                }
-            }
+            var plugins = LampaPluginBuilder.BuildOnPluginUrls(
+                ModInit.conf.initPlugins,
+                ModInit.conf.customPlugins,
+                token,
+                adult);
             #endregion
 
             string onjs = FileCache.ReadAllText($"{ModInit.modpath}/plugins/on.js", "on.js");

--- a/Modules/LampaWeb/LampaPluginBuilder.cs
+++ b/Modules/LampaWeb/LampaPluginBuilder.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using System.Web;
+
+namespace LampaWeb;
+
+public static class LampaPluginBuilder
+{
+    public static List<LampaPlugin> BuildInitPlugins(InitPlugins initPlugins, List<LampaPlugin> customPlugins, bool adult = true)
+    {
+        var plugins = new List<LampaPlugin>(20);
+        AppendEnabledPlugins(plugins, initPlugins, customPlugins, adult, useTokenRoutes: false, routeToken: null);
+        return plugins;
+    }
+
+    public static List<string> BuildOnPluginUrls(InitPlugins initPlugins, List<LampaPlugin> customPlugins, string routeToken, bool adult = true)
+    {
+        var urlStrings = new List<string>(20);
+        AppendEnabledPlugins(urlStrings, initPlugins, customPlugins, adult, useTokenRoutes: true, routeToken: routeToken);
+        return urlStrings;
+    }
+
+    static void AppendEnabledPlugins<T>(
+        List<T> target,
+        InitPlugins initPlugins,
+        List<LampaPlugin> customPlugins,
+        bool adult,
+        bool useTokenRoutes,
+        string routeToken)
+    {
+        if (initPlugins.dlna)
+            AddPlugin(target, "dlna", "DLNA", useTokenRoutes, routeToken, worktoken: true);
+
+        if (initPlugins.tracks)
+            AddPlugin(target, "tracks", "Tracks.js", useTokenRoutes, routeToken, worktoken: true);
+
+        if (initPlugins.transcoding)
+            AddPlugin(target, "transcoding", "Transcoding video", useTokenRoutes, routeToken, worktoken: true);
+
+        if (initPlugins.tmdbProxy)
+            AddPlugin(target, "tmdbproxy", "TMDB Proxy", useTokenRoutes, routeToken, worktoken: true);
+
+        if (initPlugins.cubProxy)
+            AddPlugin(target, "cubproxy", "CUB Proxy", useTokenRoutes, routeToken, worktoken: true);
+
+        if (initPlugins.online)
+            AddPlugin(target, "online", "Онлайн", useTokenRoutes, routeToken, worktoken: true);
+
+        if (initPlugins.watch_together)
+            AddPlugin(target, "watchtogether", "Watch Together", useTokenRoutes, routeToken, worktoken: false);
+
+        if (initPlugins.catalog)
+            AddPlugin(target, "catalog", "Альтернативные источники каталога", useTokenRoutes, routeToken, worktoken: true);
+
+        if (initPlugins.dorama)
+            AddPlugin(target, "dorama", "Дорамы", useTokenRoutes, routeToken, worktoken: true);
+
+        if (adult && initPlugins.sisi)
+        {
+            AddPlugin(target, "sisi", "Клубничка", useTokenRoutes, routeToken, worktoken: true);
+            AddPlugin(target, "startpage", "Стартовая страница", useTokenRoutes, routeToken, worktoken: false);
+        }
+
+        if (initPlugins.sync)
+            AddPlugin(target, "sync", "Синхронизация", useTokenRoutes, routeToken, worktoken: true);
+
+        if (!initPlugins.sync && initPlugins.timecode)
+            AddPlugin(target, "timecode", "Синхронизация тайм-кодов", useTokenRoutes, routeToken, worktoken: true);
+
+        if (!initPlugins.sync && initPlugins.bookmark)
+            AddPlugin(target, "bookmark", "Синхронизация закладок", useTokenRoutes, routeToken, worktoken: true);
+
+        if (initPlugins.torrserver)
+            AddPlugin(target, "ts", "TorrServer", useTokenRoutes, routeToken, worktoken: true);
+
+        if (initPlugins.backup)
+            AddPlugin(target, "backup", "Backup", useTokenRoutes, routeToken, worktoken: true);
+
+        if (customPlugins == null)
+            return;
+
+        foreach (var p in customPlugins)
+        {
+            if (p.status != 1)
+                continue;
+
+            if (target is List<LampaPlugin> pluginList)
+                pluginList.Add(p);
+            else if (target is List<string> urlList)
+                urlList.Add($"\"{p.url}\"");
+        }
+    }
+
+    static void AddPlugin<T>(
+        List<T> target,
+        string name,
+        string title,
+        bool useTokenRoutes,
+        string routeToken,
+        bool worktoken)
+    {
+        if (target is List<LampaPlugin> pluginList)
+        {
+            pluginList.Add(new LampaPlugin($"{{localhost}}/{name}.js", 1, title, "lampac"));
+            return;
+        }
+
+        if (target is List<string> urlList)
+        {
+            if (useTokenRoutes && worktoken && !string.IsNullOrEmpty(routeToken))
+                urlList.Add($"\"{{localhost}}/{name}/js/{HttpUtility.UrlEncode(routeToken)}\"");
+            else
+                urlList.Add($"\"{{localhost}}/{name}.js\"");
+        }
+    }
+}

--- a/Modules/LampaWeb/README.md
+++ b/Modules/LampaWeb/README.md
@@ -39,6 +39,47 @@
 - **`initPlugins.dorama`** — подключает отдельный Lampa-плагин **`/dorama.js`** в `/lampainit.js` и `/on.js`;
 - **`limit_map`** — WAF для **`^/(extensions|testaccsdb|msx/)`**.
 
+## initPlugins и конфликты URL
+
+Lampac отдаёт плагины двумя путями:
+
+| Entry point | Назначение |
+|-------------|------------|
+| **`/lampainit.js`** | Регистрация в `Lampa.Plugins` + первичные настройки клиента (`{initiale}`) |
+| **`/on.js`**, **`/on/js/{token}`** | Прямая загрузка скриптов без registry |
+
+Список плагинов для обоих маршрутов собирается **`LampaPluginBuilder`** ([`LampaPluginBuilder.cs`](LampaPluginBuilder.cs)) по флагам **`LampaWeb.initPlugins`** и **`customPlugins`**.
+
+### Default URL (flat)
+
+В `{initiale}` всегда подставляются flat-URL вида `{localhost}/online.js`, `{localhost}/sync.js` и т.д. Сервер **не** подменяет их на `*/js/{token}` автоматически.
+
+### Token URL (ручная установка)
+
+Пользователь может добавить token-вариант вручную, например `{localhost}/sync/js/myuser` или `{localhost}/online/js/myuser`. На клиенте [`plugins/lampainit.js`](plugins/lampainit.js) при каждом старте:
+
+- сравнивает server list с уже установленными плагинами;
+- **не добавляет** flat-URL, если в registry уже есть любой URL того же семейства (`name.js` и `name/js/{token}` считаются одним плагином);
+- при наличии token-варианта может удалить flat-дубликат (если в runtime Lampa доступен `Plugins.remove`).
+
+### Sync orchestrator
+
+Если включён **`initPlugins.sync`**, модуль **`sync.js`** сам загружает bookmark и timecode. Builder **не** добавляет отдельные `bookmark.js` / `timecode.js` в `{initiale}` и `/on.js`, даже если их флаги в конфиге `true`. Рекомендуется в `init.conf` при `sync: true` явно ставить `bookmark: false`, `timecode: false`.
+
+### customPlugins
+
+Записи из **`LampaWeb.customPlugins`** ( `status: 1` ) добавляются as-is. Family dedup на клиенте применяется и к ним — например, custom `{localhost}/music/js/token` блокирует добавление flat `{localhost}/music.js` из другого источника.
+
+### Плагины без token-маршрута
+
+`watchtogether.js`, `startpage.js` — dedup только по exact URL.
+
+### Регрессионный тест dedup
+
+```bash
+node Modules/LampaWeb/plugins/lampainit-dedup.test.js
+```
+
 ## Дорамы
 
 Плагин **`plugins/dorama.js`** добавляет пункт **«Дорамы»** в основное меню Lampa сразу после **«Сериалы»** и регистрирует отдельный источник **`lampac_dorama`**. Он не зависит от SISI и подключается только через **`LampaWeb.initPlugins.dorama`**.

--- a/Modules/LampaWeb/plugins/lampainit.js
+++ b/Modules/LampaWeb/plugins/lampainit.js
@@ -78,6 +78,72 @@
     }
   }, 200);
 
+  function pluginBaseName(url) {
+    if (!url) return null;
+    var tokenized = url.match(/\/([a-z0-9_-]+)\/js\//i);
+    if (tokenized) return tokenized[1].toLowerCase();
+    var nested = url.match(/\/([a-z0-9_-]+)\/([a-z0-9_-]+)\.js(\?|$)/i);
+    if (nested) return nested[2].toLowerCase();
+    var flat = url.match(/\/([a-z0-9_-]+)\.js(\?|$)/i);
+    if (flat) return flat[1].toLowerCase();
+    return null;
+  }
+
+  function hasPluginFamily(installed, baseName) {
+    return installed.some(function (p) {
+      return pluginBaseName(p.url) === baseName;
+    });
+  }
+
+  var syncOrchestratorChildren = { bookmark: true, timecode: true };
+
+  function shouldSkipPlugin(plugin, installed) {
+    if (installed.some(function (p) { return p.url == plugin.url; }))
+      return true;
+
+    var base = pluginBaseName(plugin.url);
+    if (!base) return false;
+
+    if (hasPluginFamily(installed, base))
+      return true;
+
+    if (syncOrchestratorChildren[base] && hasPluginFamily(installed, 'sync'))
+      return true;
+
+    return false;
+  }
+
+  function cleanupFamilyDuplicates(plugins) {
+    if (typeof Lampa.Plugins.remove !== 'function')
+      return plugins;
+
+    var byBase = {};
+    plugins.forEach(function (p) {
+      var base = pluginBaseName(p.url);
+      if (!base) return;
+      if (!byBase[base]) byBase[base] = [];
+      byBase[base].push(p);
+    });
+
+    var changed = false;
+    Object.keys(byBase).forEach(function (base) {
+      var group = byBase[base];
+      var hasTokenized = group.some(function (p) { return /\/js\//.test(p.url); });
+      if (!hasTokenized) return;
+      group.forEach(function (p) {
+        if (/\/js\//.test(p.url)) return;
+        if (!/\.js(\?|$)/.test(p.url)) return;
+        Lampa.Plugins.remove(p.url);
+        changed = true;
+      });
+    });
+
+    if (changed)
+      Lampa.Plugins.save();
+
+    return Lampa.Plugins.get();
+  }
+
   function start() {
     {deny}
 	
@@ -99,20 +165,21 @@
     }
 
     var plugins = Lampa.Plugins.get();
+    plugins = cleanupFamilyDuplicates(plugins);
 
     var plugins_add = {initiale};
 
     var plugins_push = [];
 
     plugins_add.forEach(function(plugin) {
-      if (!plugins.find(function(a) {
-          return a.url == plugin.url;
-        })) {
-        Lampa.Plugins.add(plugin);
-        Lampa.Plugins.save();
+      if (shouldSkipPlugin(plugin, plugins))
+        return;
 
-        plugins_push.push(plugin.url);
-      }
+      Lampa.Plugins.add(plugin);
+      Lampa.Plugins.save();
+
+      plugins_push.push(plugin.url);
+      plugins.push(plugin);
     });
 
     if (plugins_push.length) Lampa.Utils.putScript(plugins_push, function() {}, function() {}, function() {}, true);


### PR DESCRIPTION
- Introduced LampaPluginBuilder class to centralize the logic for building and managing plugins based on initialization flags and custom plugins.
- Refactored ApiController to utilize LampaPluginBuilder for initializing and generating plugin lists.
- Updated README.md to document the new plugin management approach and its implications for URL handling and deduplication.