### PR TITLE
fix(LampaWeb): add LampaPluginBuilder.cs to manifest tree

### DIFF
--- a/Modules/LampaWeb/manifest.json
+++ b/Modules/LampaWeb/manifest.json
@@ -5,6 +5,7 @@
     "Controllers",
     "Models",
     "Services",
+    "LampaPluginBuilder.cs",
     "ModInit.cs"
   ]
 }


### PR DESCRIPTION
Релиз 1.50.0 не стартует: контейнер уходит в crash-loop.

```
/lampac/module/LampaWeb/Controllers/ApiController.cs(700,27): error CS0103: Имя "LampaPluginBuilder" не существует в текущем контексте.
/lampac/module/LampaWeb/Controllers/ApiController.cs(833,27): error CS0103: Имя "LampaPluginBuilder" не существует в текущем контексте.

error compilation /lampac/module/LampaWeb
Unhandled exception. System.Exception: Exception of type 'System.Exception' was thrown.
   at Core.Startup.ConfigureServices(IServiceCollection services)
```

LampaWeb не компилируется, `ConfigureServices` бросает исключение, процесс падает и рестартует по кругу.

Причина. В #175 добавлен `Modules/LampaWeb/LampaPluginBuilder.cs` в корне модуля, а `manifest.json` перечисляет компилируемые пути явным списком `tree` — туда попали `Controllers`, `Models`, `Services` и `ModInit.cs`, но не новый файл. Roslyn его не видит, а `ApiController` на него ссылается.

Как повторить: `docker run ghcr.io/lampac-nextgen/lampac:1.50.0` без конфига. Воспроизвёл на Hetzner ARM (aarch64).

Проверял на той же машине: подмонтировал `manifest.json` с одной добавленной строкой в неизменённый образ 1.50.0 — `loaded module: LampaWeb`, `Configure complete`, контейнер `healthy`.
