### PR TITLE
fix(Videoseed): improve serial voice selection

### DIFF
--- a/Modules/OnlineRUS/Vibix/Controller.cs
+++ b/Modules/OnlineRUS/Vibix/Controller.cs
@@ -23,7 +23,7 @@ public class VibixController : BaseOnlineController
 
     [HttpGet, Staticache(manually: true)]
     [Route("lite/vibix")]
-    async public Task<ActionResult> Index(string imdb_id, long kinopoisk_id, string title, string original_title, short s = -1, bool rjson = false)
+    async public Task<ActionResult> Index(string imdb_id, long kinopoisk_id, string title, string original_title, short s = -1, bool rjson = false, string voice = null)
     {
         if (await IsRequestBlocked(rch: false))
             return badInitMsg;
@@ -71,13 +71,13 @@ public class VibixController : BaseOnlineController
 
                         foreach (Match voiceMatch in Regex.Matches(items, @"\{(?<voice>[^}]+)\}(?<file>https?://[^,\t\[\;{ ]+)", RegexOptions.Singleline))
                         {
-                            string voice = voiceMatch.Groups["voice"].Value;
+                            string movieVoice = voiceMatch.Groups["voice"].Value;
                             string file = voiceMatch.Groups["file"].Value;
 
-                            if (!movie.voices.TryGetValue(voice, out var streams))
+                            if (!movie.voices.TryGetValue(movieVoice, out var streams))
                             {
                                 streams = new List<StreamQualityDto>();
-                                movie.voices[voice] = streams;
+                                movie.voices[movieVoice] = streams;
                             }
 
                             streams.Insert(0, new StreamQualityDto(
@@ -113,6 +113,8 @@ public class VibixController : BaseOnlineController
             #region Сериал
             string enc_title = HttpUtility.UrlEncode(title);
             string enc_original_title = HttpUtility.UrlEncode(original_title);
+            string enc_imdb_id = HttpUtility.UrlEncode(imdb_id);
+            string serialQuery = $"rjson={rjson}&kinopoisk_id={kinopoisk_id}&imdb_id={enc_imdb_id}&title={enc_title}&original_title={enc_original_title}";
 
             if (s == -1)
             {
@@ -124,7 +126,7 @@ public class VibixController : BaseOnlineController
                     {
                         tpl.Append(
                             $"{_s} сезон",
-                            $"{host}/lite/vibix?rjson={rjson}&kinopoisk_id={kinopoisk_id}&imdb_id={imdb_id}&title={enc_title}&original_title={enc_original_title}&s={_s}",
+                            $"{host}/lite/vibix?{serialQuery}&s={_s}",
                             _s
                         );
                     }
@@ -134,51 +136,89 @@ public class VibixController : BaseOnlineController
             }
             else
             {
-                var etpl = new EpisodeTpl();
+                var season = cache.Value.FirstOrDefault(i => i.title?.EndsWith($" {s}") == true);
+                var episodes = season?.folder?
+                    .Where(i => i != null)
+                    .OrderBy(i => SortNumber(i.title))
+                    .ThenBy(i => i.title, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
 
-                foreach (var season in cache.Value)
+                if (episodes == null || episodes.Count == 0)
+                    return ContentTpl(new EpisodeTpl());
+
+                foreach (var episode in episodes)
+                    PrepareEpisode(episode);
+
+                var voices = new List<string>();
+                var seenVoices = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var episode in episodes)
                 {
-                    if (!season.title.EndsWith($" {s}"))
+                    if (episode.voices == null)
                         continue;
 
-                    foreach (var episode in season.folder)
+                    foreach (string voiceName in episode.voices.Keys)
                     {
-                        string name = episode.title;
-                        string file = episode.folder?.First().file ?? episode.file;
+                        if (!string.IsNullOrWhiteSpace(voiceName) && seenVoices.Add(voiceName))
+                            voices.Add(voiceName);
+                    }
+                }
 
-                        if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(file))
+                string selectedVoice = voice;
+                string activeVoice = selectedVoice;
+
+                if (string.IsNullOrEmpty(activeVoice))
+                    activeVoice = GetEpisodeDefaultVoice(episodes.FirstOrDefault());
+
+                if (!string.IsNullOrEmpty(activeVoice) && !seenVoices.Contains(activeVoice))
+                    activeVoice = null;
+
+                VoiceTpl vtpl = null;
+                string seasonLink = $"{host}/lite/vibix?{serialQuery}&s={s}";
+
+                if (voices.Count > 0)
+                {
+                    vtpl = new VoiceTpl(voices.Count);
+
+                    foreach (string voiceName in voices)
+                    {
+                        vtpl.Append(
+                            voiceName,
+                            string.Equals(activeVoice, voiceName, StringComparison.OrdinalIgnoreCase),
+                            $"{seasonLink}&voice={HttpUtility.UrlEncode(voiceName)}"
+                        );
+                    }
+                }
+
+                var etpl = new EpisodeTpl(vtpl, episodes.Count);
+
+                foreach (var episode in episodes)
+                {
+                    List<StreamQualityDto> streams = episode.streams;
+
+                    if (!string.IsNullOrEmpty(selectedVoice))
+                    {
+                        if (episode.voices == null ||
+                            !episode.voices.TryGetValue(selectedVoice, out streams) ||
+                            streams == null ||
+                            streams.Count == 0)
+                        {
                             continue;
-
-                        if (episode.streams == null)
-                        {
-                            episode.streams = new List<StreamQualityDto>(3);
-
-                            foreach (string q in new string[] { "1080", "720", "480" })
-                            {
-                                var g = new Regex($"{q}p?\\](\\{{[^\\}}]+\\}})?(?<file>https?://[^,\t\\[\\;\\{{ ]+)").Match(file).Groups;
-                                if (!string.IsNullOrEmpty(g["file"].Value))
-                                {
-                                    episode.streams.Add(new StreamQualityDto(
-                                        $"{host}/lite/vibix/video.m3u8?id={EncryptQuery(g["file"].Value)}",
-                                        $"{q}p"
-                                    ));
-                                }
-                            }
-                        }
-
-                        if (episode.streams.Count > 0)
-                        {
-                            etpl.Append(
-                                name,
-                                title ?? original_title,
-                                s,
-                                Regex.Match(name, "([0-9]+)").Groups[1].Value,
-                                accsArgs(episode.streams[0].link),
-                                streamquality: new StreamQualityTpl(episode.streams, linkPredicate: accsArgs),
-                                vast: init.vast
-                            );
                         }
                     }
+
+                    if (string.IsNullOrEmpty(episode.title) || streams == null || streams.Count == 0)
+                        continue;
+
+                    etpl.Append(
+                        episode.title,
+                        title ?? original_title,
+                        s,
+                        Regex.Match(episode.title, "([0-9]+)").Groups[1].Value,
+                        accsArgs(streams[0].link),
+                        streamquality: new StreamQualityTpl(streams, linkPredicate: accsArgs),
+                        vast: init.vast
+                    );
                 }
 
                 return ContentTpl(etpl);
@@ -239,6 +279,187 @@ public class VibixController : BaseOnlineController
         return Content(m3u8, "application/vnd.apple.mpegurl");
     }
     #endregion
+
+    #region EpisodeVoices
+    void PrepareEpisode(Item episode)
+    {
+        if (episode == null || (episode.streams != null && episode.voices != null))
+            return;
+
+        episode.voices = new Dictionary<string, List<StreamQualityDto>>(StringComparer.OrdinalIgnoreCase);
+
+        var sources = episode.folder?
+            .Where(i => i != null && !string.IsNullOrWhiteSpace(i.file))
+            .ToList();
+
+        if (sources?.Count > 0)
+        {
+            Item nativeSource = sources[0];
+
+            foreach (var source in sources)
+            {
+                var inlineVoices = ExtractVoices(source.file);
+
+                if (inlineVoices.Count > 0)
+                {
+                    foreach (string voiceName in inlineVoices)
+                        AddVoice(episode.voices, voiceName, BuildStreams(source.file, voiceName));
+                }
+                else if (!string.IsNullOrWhiteSpace(source.title))
+                {
+                    AddVoice(episode.voices, source.title.Trim(), BuildStreams(source.file));
+                }
+            }
+
+            string taggedDefault = GetDefaultVoice(nativeSource.file);
+            episode.streams = BuildStreams(nativeSource.file, taggedDefault);
+        }
+        else
+        {
+            var inlineVoices = ExtractVoices(episode.file);
+
+            foreach (string voiceName in inlineVoices)
+                AddVoice(episode.voices, voiceName, BuildStreams(episode.file, voiceName));
+
+            string taggedDefault = GetDefaultVoice(episode.file);
+            episode.streams = BuildStreams(episode.file, taggedDefault);
+        }
+    }
+
+    static string GetEpisodeDefaultVoice(Item episode)
+    {
+        if (episode == null)
+            return null;
+
+        var nativeSource = episode.folder?
+            .FirstOrDefault(i => i != null && !string.IsNullOrWhiteSpace(i.file));
+
+        if (nativeSource != null)
+        {
+            string taggedDefault = GetDefaultVoice(nativeSource.file);
+            return !string.IsNullOrEmpty(taggedDefault)
+                ? taggedDefault
+                : nativeSource.title?.Trim();
+        }
+
+        return GetDefaultVoice(episode.file);
+    }
+
+    List<StreamQualityDto> BuildStreams(string file, string voice = null)
+    {
+        var streams = new List<StreamQualityDto>(3);
+
+        if (string.IsNullOrWhiteSpace(file))
+            return streams;
+
+        foreach (string q in new string[] { "1080", "720", "480" })
+        {
+            Match qualityMatch = Regex.Match(
+                file,
+                $@"\[{q}p?\](?<items>.*?)(?=,\[(?:480|720|1080)p?\]|$)",
+                RegexOptions.Singleline
+            );
+
+            if (!qualityMatch.Success)
+                continue;
+
+            string items = qualityMatch.Groups["items"].Value;
+            Match selected;
+
+            if (!string.IsNullOrEmpty(voice))
+            {
+                selected = Regex.Match(
+                    items,
+                    @"\{" + Regex.Escape(voice) + @"\}(?<file>https?://[^,\t\[\;{ ]+)",
+                    RegexOptions.IgnoreCase | RegexOptions.Singleline
+                );
+            }
+            else
+            {
+                selected = Regex.Match(
+                    items,
+                    @"(?:\{[^}]+\})?(?<file>https?://[^,\t\[\;{ ]+)",
+                    RegexOptions.Singleline
+                );
+            }
+
+            if (!selected.Success)
+                continue;
+
+            streams.Add(new StreamQualityDto(
+                $"{host}/lite/vibix/video.m3u8?id={EncryptQuery(selected.Groups["file"].Value)}",
+                $"{q}p"
+            ));
+        }
+
+        return streams;
+    }
+
+    static List<string> ExtractVoices(string file)
+    {
+        var voices = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (string.IsNullOrWhiteSpace(file))
+            return voices;
+
+        foreach (Match qualityMatch in Regex.Matches(
+            file,
+            @"\[(?:480|720|1080)p?\](?<items>.*?)(?=,\[(?:480|720|1080)p?\]|$)",
+            RegexOptions.Singleline))
+        {
+            foreach (Match voiceMatch in Regex.Matches(
+                qualityMatch.Groups["items"].Value,
+                @"\{(?<voice>[^}]+)\}(?<file>https?://[^,\t\[\;{ ]+)",
+                RegexOptions.Singleline))
+            {
+                string voiceName = voiceMatch.Groups["voice"].Value.Trim();
+
+                if (!string.IsNullOrEmpty(voiceName) && seen.Add(voiceName))
+                    voices.Add(voiceName);
+            }
+        }
+
+        return voices;
+    }
+
+    static string GetDefaultVoice(string file)
+    {
+        if (string.IsNullOrWhiteSpace(file))
+            return null;
+
+        Match qualityMatch = Regex.Match(
+            file,
+            @"\[(?:480|720|1080)p?\](?<items>.*?)(?=,\[(?:480|720|1080)p?\]|$)",
+            RegexOptions.Singleline
+        );
+
+        if (!qualityMatch.Success)
+            return null;
+
+        Match firstStream = Regex.Match(
+            qualityMatch.Groups["items"].Value,
+            @"(?:\{(?<voice>[^}]+)\})?(?<file>https?://[^,\t\[\;{ ]+)",
+            RegexOptions.Singleline
+        );
+
+        if (!firstStream.Success)
+            return null;
+
+        string voiceName = firstStream.Groups["voice"].Value.Trim();
+        return string.IsNullOrEmpty(voiceName) ? null : voiceName;
+    }
+
+    static void AddVoice(Dictionary<string, List<StreamQualityDto>> voices, string voiceName, List<StreamQualityDto> streams)
+    {
+        if (string.IsNullOrWhiteSpace(voiceName) || streams == null || streams.Count == 0)
+            return;
+
+        if (!voices.ContainsKey(voiceName))
+            voices[voiceName] = streams;
+    }
+    #endregion
+
 
     #region black_magic
     async Task<string> black_magic(string imdb_id, long kinopoisk_id)
@@ -321,6 +542,17 @@ public class VibixController : BaseOnlineController
     }
     #endregion
 
+
+    static int SortNumber(string value)
+    {
+        if (int.TryParse(value, out int number))
+            return number;
+
+        var match = Regex.Match(value ?? string.Empty, "[0-9]+");
+        return match.Success && int.TryParse(match.Value, out number)
+            ? number
+            : int.MaxValue;
+    }
 
     static string PadBase64(string value)
     {

--- a/Modules/OnlineRUS/Videoseed/Controller.cs
+++ b/Modules/OnlineRUS/Videoseed/Controller.cs
@@ -20,7 +20,7 @@ public class VideoseedController : BaseOnlineController
 
     [HttpGet, Staticache(manually: true)]
     [Route("lite/videoseed")]
-    async public Task<ActionResult> Index(string imdb_id, long kinopoisk_id, string title, string original_title, short year, short s = -1, bool rjson = false, short serial = -1)
+    async public Task<ActionResult> Index(string imdb_id, long kinopoisk_id, string title, string original_title, short year, short s = -1, bool rjson = false, short serial = -1, string voice = null)
     {
         if (PlaywrightBrowser.Status == PlaywrightStatus.disabled)
             return OnError();
@@ -31,7 +31,7 @@ public class VideoseedController : BaseOnlineController
         if (string.IsNullOrEmpty(init.token))
             return OnError();
 
-        var cache = await InvokeCacheResult<Data>($"videoseed:view:{kinopoisk_id}:{imdb_id}:{original_title}", TimeSpan.FromHours(4), async e =>
+        var cache = await InvokeCacheResult<Data>($"videoseed:view:{serial}:{kinopoisk_id}:{imdb_id}:{original_title}:{year}", TimeSpan.FromHours(4), async e =>
         {
             var data =
                 await goSearch(serial, kinopoisk_id > 0, $"&kp={kinopoisk_id}") ??
@@ -54,16 +54,20 @@ public class VideoseedController : BaseOnlineController
                 #region Сериал
                 string enc_title = HttpUtility.UrlEncode(title);
                 string enc_original_title = HttpUtility.UrlEncode(original_title);
+                string enc_imdb_id = HttpUtility.UrlEncode(imdb_id);
+                string serialQuery = $"rjson={rjson}&kinopoisk_id={kinopoisk_id}&imdb_id={enc_imdb_id}&title={enc_title}&original_title={enc_original_title}&year={year}&serial=1";
 
                 if (s == -1)
                 {
                     var tpl = new SeasonTpl(cache.Value.seasons.Count);
 
-                    foreach (var season in cache.Value.seasons)
+                    foreach (var season in cache.Value.seasons
+                        .OrderBy(i => SortNumber(i.Key))
+                        .ThenBy(i => i.Key, StringComparer.OrdinalIgnoreCase))
                     {
                         tpl.Append(
                             $"{season.Key} сезон",
-                            $"{host}/lite/videoseed?rjson={rjson}&kinopoisk_id={kinopoisk_id}&imdb_id={imdb_id}&title={enc_title}&original_title={enc_original_title}&s={season.Key}",
+                            $"{host}/lite/videoseed?{serialQuery}&s={season.Key}",
                             season.Key
                         );
                     }
@@ -72,21 +76,99 @@ public class VideoseedController : BaseOnlineController
                 }
                 else
                 {
-                    string sArhc = s.ToString();
-                    var videos = cache.Value.seasons.FirstOrDefault(i => i.Key == sArhc).Value?.videos;
+                    var season = cache.Value.seasons
+                        .FirstOrDefault(i => i.Key == s.ToString() || SortNumber(i.Key) == s)
+                        .Value;
+
+                    var videos = season?.videos;
                     if (videos == null)
                         return default;
 
-                    var etpl = new EpisodeTpl(videos.Count);
+                    string seasonLink = $"{host}/lite/videoseed?{serialQuery}&s={s}";
+                    var translations = season.translation_iframe?.Count > 0
+                        ? season.translation_iframe
+                        : cache.Value.translation_iframe;
 
-                    foreach (var video in videos)
+                    VoiceTpl vtpl = null;
+                    string selectedVoice = voice;
+                    string activeVoice = selectedVoice;
+
+                    if (string.IsNullOrEmpty(activeVoice))
                     {
+                        activeVoice = videos
+                            .OrderBy(i => SortNumber(i.Key))
+                            .ThenBy(i => i.Key, StringComparer.OrdinalIgnoreCase)
+                            .FirstOrDefault()
+                            .Value?
+                            .short_translation;
+                    }
+
+                    if (translations?.Count > 0)
+                    {
+                        var voices = translations
+                            .Select(i => i.Value?.short_name ?? i.Value?.name ?? i.Key)
+                            .Where(i => !string.IsNullOrEmpty(i))
+                            .Distinct(StringComparer.OrdinalIgnoreCase)
+                            .OrderBy(i => i, StringComparer.OrdinalIgnoreCase)
+                            .ToList();
+
+                        if (voices.Count > 0)
+                        {
+                            if (!voices.Any(i => string.Equals(i, activeVoice, StringComparison.OrdinalIgnoreCase)))
+                                activeVoice = null;
+
+                            vtpl = new VoiceTpl(voices.Count);
+
+                            foreach (string voiceName in voices)
+                            {
+                                vtpl.Append(
+                                    voiceName,
+                                    string.Equals(activeVoice, voiceName, StringComparison.OrdinalIgnoreCase),
+                                    $"{seasonLink}&voice={HttpUtility.UrlEncode(voiceName)}"
+                                );
+                            }
+                        }
+                    }
+
+                    var etpl = new EpisodeTpl(vtpl, videos.Count);
+
+                    foreach (var video in videos
+                        .OrderBy(i => SortNumber(i.Key))
+                        .ThenBy(i => i.Key, StringComparer.OrdinalIgnoreCase))
+                    {
+                        string selectedIframe = video.Value.iframe;
+                        string fallbackVoice = selectedVoice;
+
+                        if (!string.IsNullOrEmpty(selectedVoice) && video.Value.translation_iframe?.Count > 0)
+                        {
+                            var translation = video.Value.translation_iframe
+                                .FirstOrDefault(i => string.Equals(
+                                    i.Value?.short_name ?? i.Value?.name ?? i.Key,
+                                    selectedVoice,
+                                    StringComparison.OrdinalIgnoreCase
+                                ))
+                                .Value;
+
+                            if (!string.IsNullOrEmpty(translation?.iframe))
+                            {
+                                selectedIframe = translation.iframe;
+                                fallbackVoice = null;
+                            }
+                        }
+
+                        string link = accsArgs($"{host}/lite/videoseed/video/{AesTo.Encrypt(selectedIframe)}");
+
+                        // Older/incomplete API responses may not contain episode-level translation_iframe.
+                        // Keep the strict PlayerJS voice lookup only as a compatibility fallback.
+                        if (!string.IsNullOrEmpty(fallbackVoice))
+                            link += $"&voice={HttpUtility.UrlEncode(fallbackVoice)}";
+
                         etpl.Append(
                             $"{video.Key} серия",
                             title ?? original_title,
                             s,
                             video.Key,
-                            accsArgs($"{host}/lite/videoseed/video/{AesTo.Encrypt(video.Value.iframe)}") + "#.m3u8",
+                            link + "#.m3u8",
                             "call",
                             vast: init.vast
                         );
@@ -105,11 +187,11 @@ public class VideoseedController : BaseOnlineController
                 {
                     foreach (var translation in cache.Value.translation_iframe)
                     {
-                        string voice = translation.Value.short_name;
+                        string translationVoice = translation.Value.short_name;
 
                         mtpl.Append(
-                            voice ?? translation.Value.name ?? translation.Key,
-                            accsArgs($"{host}/lite/videoseed/video/{AesTo.Encrypt(cache.Value.iframe)}") + $"&voice={HttpUtility.UrlEncode(voice)}" + "#.m3u8",
+                            translationVoice ?? translation.Value.name ?? translation.Key,
+                            accsArgs($"{host}/lite/videoseed/video/{AesTo.Encrypt(cache.Value.iframe)}") + $"&voice={HttpUtility.UrlEncode(translationVoice)}" + "#.m3u8",
                             "call",
                             vast: init.vast
                         );
@@ -237,13 +319,23 @@ public class VideoseedController : BaseOnlineController
         if (!cache.IsSuccess)
             return OnError(cache.ErrorMsg);
 
-        string location = null;
+        string location;
 
-        if (voice != null)
-            location = Regex.Match(cache.Value, "\\{" + voice + "\\} ?(https?://[^\\;\\{\"\n\r\t ]+\\.m3u8)").Groups[1].Value;
+        if (!string.IsNullOrEmpty(voice))
+        {
+            location = Regex.Match(
+                cache.Value,
+                "\\{" + Regex.Escape(voice) + "\\} ?(https?://[^\\;\\{\"\n\r\t ]+\\.m3u8)",
+                RegexOptions.IgnoreCase
+            ).Groups[1].Value;
 
-        if (string.IsNullOrEmpty(location))
+            if (string.IsNullOrEmpty(location))
+                return OnError("voice_location");
+        }
+        else
+        {
             location = Regex.Match(cache.Value, "(https?://[^\\;\\{\"\n\r\t ]+\\.m3u8)").Groups[1].Value;
+        }
 
         if (string.IsNullOrEmpty(location))
             return OnError("location");
@@ -278,4 +370,15 @@ public class VideoseedController : BaseOnlineController
         return root.data.FirstOrDefault();
     }
     #endregion
+
+    static int SortNumber(string value)
+    {
+        if (int.TryParse(value, out int number))
+            return number;
+
+        var match = Regex.Match(value ?? string.Empty, "[0-9]+");
+        return match.Success && int.TryParse(match.Value, out number)
+            ? number
+            : int.MaxValue;
+    }
 }

--- a/Modules/OnlineRUS/Videoseed/Model.cs
+++ b/Modules/OnlineRUS/Videoseed/Model.cs
@@ -21,11 +21,19 @@ public class Data
 public class Season
 {
     public Dictionary<string, Episode> videos { get; set; }
+
+    public Dictionary<string, Translation> translation_iframe { get; set; }
 }
 
 public class Episode
 {
     public string iframe { get; set; }
+
+    public string translations_id { get; set; }
+
+    public string short_translation { get; set; }
+
+    public Dictionary<string, Translation> translation_iframe { get; set; }
 }
 
 public class Translation
@@ -35,4 +43,6 @@ public class Translation
     public string short_name { get; set; }
 
     public string iframe { get; set; }
+
+    public int count { get; set; }
 }


### PR DESCRIPTION
- add season and episode translation metadata
- use episode-specific voice iframes from the API
- mark the first episode's native voice as active by default
- avoid Playwright when opening a season
- keep native per-episode default audio when no voice is selected
- sort seasons and episodes numerically
- preserve serial/year navigation and cache identity