### PR TITLE
fix(OnlineENG): update dead/moved ENG source hosts, disable SmashyStream by default

### DIFF
--- a/Modules/OnlineENG/AutoEmbed/ModInit.cs
+++ b/Modules/OnlineENG/AutoEmbed/ModInit.cs
@@ -46,7 +46,7 @@ public class ModInit : IModuleLoaded, IModuleOnline
 
     private void UpdateConf()
     {
-        conf = ModuleInvoke.Init("Autoembed", new OnlinesSettings("Autoembed", "https://player.autoembed.cc")
+        conf = ModuleInvoke.Init("Autoembed", new OnlinesSettings("Autoembed", "https://player.autoembed.to")
         {
             enable = false,
             displayindex = 1035,

--- a/Modules/OnlineENG/HydraFlix/ModInit.cs
+++ b/Modules/OnlineENG/HydraFlix/ModInit.cs
@@ -49,7 +49,7 @@ public class ModInit : IModuleLoaded, IModuleOnline
         /// <summary>
         /// https://www.hydraflix.cc
         /// </summary>
-        conf = ModuleInvoke.Init("Hydraflix", new OnlinesSettings("Hydraflix", "https://vidfast.pro")
+        conf = ModuleInvoke.Init("Hydraflix", new OnlinesSettings("Hydraflix", "https://vidfast.vc")
         {
             displayindex = 1000,
             streamproxy = true,

--- a/Modules/OnlineENG/SmashyStream/ModInit.cs
+++ b/Modules/OnlineENG/SmashyStream/ModInit.cs
@@ -50,6 +50,8 @@ public class ModInit : IModuleLoaded, IModuleOnline
         // https://anyembed.xyz/
         conf = ModuleInvoke.Init("Smashystream", new OnlinesSettings("Smashystream", "https://anyembed.xyz")
         {
+            // anyembed.xyz returns 451 (DMCA); no working drop-in mirror — disabled by default
+            enable = false,
             displayindex = 1030,
             streamproxy = true
         });

--- a/Modules/OnlineENG/TwoEmbed/ModInit.cs
+++ b/Modules/OnlineENG/TwoEmbed/ModInit.cs
@@ -49,7 +49,7 @@ public class ModInit : IModuleLoaded, IModuleOnline
         /// <summary>
         /// EmbedSu
         /// </summary>
-        conf = ModuleInvoke.Init("Twoembed", new OnlinesSettings("Twoembed", "https://embed.su")
+        conf = ModuleInvoke.Init("Twoembed", new OnlinesSettings("Twoembed", "https://www.2embed.cc")
         {
             enable = false,
             displayindex = 1045,
@@ -57,8 +57,8 @@ public class ModInit : IModuleLoaded, IModuleOnline
             headers_stream = HeadersModel.Init(
                 ("accept", "*/*"),
                 ("accept-language", "en-US,en;q=0.5"),
-                ("referer", "https://embed.su/"),
-                ("origin", "https://embed.su"),
+                ("referer", "https://www.2embed.cc/"),
+                ("origin", "https://www.2embed.cc"),
                 ("sec-fetch-dest", "empty"),
                 ("sec-fetch-mode", "cors"),
                 ("sec-fetch-site", "cross-site")

--- a/Modules/OnlineENG/VidSrc/ModInit.cs
+++ b/Modules/OnlineENG/VidSrc/ModInit.cs
@@ -46,7 +46,7 @@ public class ModInit : IModuleLoaded, IModuleOnline
 
     private void UpdateConf()
     {
-        conf = ModuleInvoke.Init("Vidsrc", new OnlinesSettings("Vidsrc", "https://vidsrc.cc")
+        conf = ModuleInvoke.Init("Vidsrc", new OnlinesSettings("Vidsrc", "https://vidsrc.pm")
         {
             displayindex = 1005,
             streamproxy = true

--- a/Modules/OnlineENG/Videasy/ModInit.cs
+++ b/Modules/OnlineENG/Videasy/ModInit.cs
@@ -46,7 +46,7 @@ public class ModInit : IModuleLoaded, IModuleOnline
 
     private void UpdateConf()
     {
-        conf = ModuleInvoke.Init("Videasy", new OnlinesSettings("Videasy", "https://player.videasy.net")
+        conf = ModuleInvoke.Init("Videasy", new OnlinesSettings("Videasy", "https://player.videasy.to")
         {
             displayindex = 1020,
             streamproxy = true


### PR DESCRIPTION
## Problem (refs #181)

Most OnlineENG sources are broken because their default hosts are dead, DMCA-blocked, or moved to new domains.

Verified today with live requests (direct + via proxy), probing the exact embed endpoints the controllers build:

| Module | Old host | Status | New host | Embed check |
|---|---|---|---|---|
| VidSrc | vidsrc.cc | dead | **vidsrc.pm** | `/v2/embed/movie/550` → 200 |
| Videasy | player.videasy.net | 301 moved | **player.videasy.to** | `/movie/550` → 200 |
| HydraFlix | vidfast.pro | 301 moved | **vidfast.vc** | `/movie/550` → 200 |
| AutoEmbed | player.autoembed.cc | dead | **player.autoembed.to** | `/embed/movie/550` → 200 |
| TwoEmbed | embed.su | dead | **www.2embed.cc** | `/embed/movie/550` → 200 |
| SmashyStream | anyembed.xyz | **451 (DMCA)** | — | no drop-in mirror found |
| RgShows | api.rgshows.me | whole service down | — | already `enable = false` upstream |
| MovPI / VidLink | moviesapi.to / vidlink.pro | alive | unchanged | — |

Notes:
- vidsrc.to was **rejected**: it serves the old `/embed/` path, while the module uses `/v2/embed/` — vidsrc.pm is the compatible mirror.
- TwoEmbed: also updated the hardcoded `referer`/`origin` stream headers (players validate them; a host-only change would 403).
- SmashyStream: `anyembed.xyz` returns HTTP 451; disabled by default until a compatible mirror appears.
- PlayEmbed left untouched (already disabled upstream; vidora.cc is alive but not path-compatible).

Users who can't wait for a release can override hosts without code changes via init.conf, e.g. `"Vidsrc": { "host": "https://vidsrc.pm" }`.