### PR TITLE
fix(FlixCDN): restore movie playback and enable source

### DIFF
--- a/Modules/OnlineRUS/FlixCDN/Controller.cs
+++ b/Modules/OnlineRUS/FlixCDN/Controller.cs
@@ -235,7 +235,7 @@ public class FlixCDNController : BaseOnlineController
         }
 
         if (seasons.Count == 0 && player?.season > 0 && player.episodes?.Length > 0)
-            seasons[player.season] = player.episodes.Where(e => e > 0).ToArray();
+            seasons[player.season.Value] = player.episodes.Where(e => e > 0).ToArray();
 
         return seasons;
     }

--- a/Modules/OnlineRUS/FlixCDN/ModInit.cs
+++ b/Modules/OnlineRUS/FlixCDN/ModInit.cs
@@ -40,7 +40,7 @@ public class ModInit : IModuleLoaded, IModuleOnline
     {
         conf = ModuleInvoke.Init("FlixCDN", new OnlinesSettings("FlixCDN", "https://tarantino.factorios.live", "https://api0.flixcdn.biz/api", streamproxy: true)
         {
-            enable = false,
+            enable = true,
             displayindex = 525,
             stream_access = "apk,cors,web",
             headers_stream = HeadersModel.Init(

--- a/Modules/OnlineRUS/FlixCDN/Model.cs
+++ b/Modules/OnlineRUS/FlixCDN/Model.cs
@@ -14,7 +14,7 @@ public class PlayerPayload
 
     public string translateTitle { get; set; }
 
-    public short season { get; set; }
+    public short? season { get; set; }
 
     public int[] episodes { get; set; }
 

--- a/Modules/OnlineRUS/FlixCDN/README.md
+++ b/Modules/OnlineRUS/FlixCDN/README.md
@@ -1,6 +1,6 @@
 # FlixCDN
 
-Онлайн-источник **FlixCDN**: два базовых URL в **`OnlinesSettings`** — плеер **`https://player0.flixcdn.space`**, API **`https://api0.flixcdn.biz/api`**, **`streamproxy: true`**. По умолчанию в шаблоне **`enable = false`**.
+Онлайн-источник **FlixCDN**: прямой плеер **`https://tarantino.factorios.live`**, **`streamproxy: true`**. По умолчанию источник включён: **`enable = true`**.
 
 ## Интерфейс
 


### PR DESCRIPTION
## Что исправлено

- `PlayerPayload.season` сделан nullable, поскольку для фильмов player API возвращает `"season": null`;
- fallback сезона извлекает значение только после существующей проверки `season > 0`;
- источник включён штатным дефолтом `enable = true` в `ModInit`;
- README приведён к актуальному host и состоянию источника.

Без nullable-поля payload фильма не десериализуется, `GetPlayer()` возвращает `null`, а endpoint отвечает `503 player`.

## Проверка

- фильм: список озвучек загружается;
- сериал: сезоны, озвучки и серии загружаются;
- stream endpoint возвращает 360p/480p/720p/1080p;
- модуль компилируется и загружается в Lampac.