### PR TITLE
fix(Music): improve player controls, radio and discovery

### DIFF
--- a/Modules/Music/Controllers/PlaybackController.cs
+++ b/Modules/Music/Controllers/PlaybackController.cs
@@ -6,10 +6,10 @@ public class PlaybackController : BaseController
 {
     [HttpGet]
     [Route("music/matches")]
-    async public Task<ActionResult> Matches(string id, string provider, string audio_provider, string playback_mode, string title, string artist_name, string album_title, int? duration_ms, string date, string isrc, string query)
+    async public Task<ActionResult> Matches(string id, string provider, string audio_provider, string playback_mode, string title, string artist_name, string album_id, string album_title, int? duration_ms, string date, string isrc, string query)
     {
         string profileId = MusicProfileIdentity.Resolve(requestInfo, Request);
-        var track = await MusicPlaybackService.ResolveRequestTrackAsync(id, provider, title, artist_name, album_title, duration_ms, date, isrc);
+        var track = await MusicPlaybackService.ResolveRequestTrackAsync(id, provider, title, artist_name, album_id, album_title, duration_ms, date, isrc);
 
         var result = string.IsNullOrWhiteSpace(query)
             ? await MusicResolver.GetMatchesAsync(track, audio_provider, playback_mode, profileId)
@@ -20,10 +20,10 @@ public class PlaybackController : BaseController
 
     [HttpPost]
     [Route("music/match/select")]
-    async public Task<ActionResult> SelectMatch(string id, string provider, string audio_provider, string playback_mode, string match_id, string title, string artist_name, string album_title, int? duration_ms, string date, string isrc, string query)
+    async public Task<ActionResult> SelectMatch(string id, string provider, string audio_provider, string playback_mode, string match_id, string title, string artist_name, string album_id, string album_title, int? duration_ms, string date, string isrc, string query)
     {
         string profileId = MusicProfileIdentity.Resolve(requestInfo, Request);
-        var track = await MusicPlaybackService.ResolveRequestTrackAsync(id, provider, title, artist_name, album_title, duration_ms, date, isrc);
+        var track = await MusicPlaybackService.ResolveRequestTrackAsync(id, provider, title, artist_name, album_id, album_title, duration_ms, date, isrc);
         bool saved = await MusicResolver.SelectMatchAsync(track, audio_provider, match_id, playback_mode, profileId, query);
 
         return ContentTo(MusicJson.Serialize(new
@@ -37,9 +37,9 @@ public class PlaybackController : BaseController
 
     [HttpPost]
     [Route("music/match/reset")]
-    async public Task<ActionResult> ResetMatch(string id, string provider, string playback_mode, string title, string artist_name, string album_title, int? duration_ms, string date, string isrc)
+    async public Task<ActionResult> ResetMatch(string id, string provider, string playback_mode, string title, string artist_name, string album_id, string album_title, int? duration_ms, string date, string isrc)
     {
-        var track = await MusicPlaybackService.ResolveRequestTrackAsync(id, provider, title, artist_name, album_title, duration_ms, date, isrc);
+        var track = await MusicPlaybackService.ResolveRequestTrackAsync(id, provider, title, artist_name, album_id, album_title, duration_ms, date, isrc);
         bool reset = track != null && await MusicSourceMatchService.DeleteAsync(track.id, playback_mode);
 
         return ContentTo(MusicJson.Serialize(new
@@ -51,10 +51,10 @@ public class PlaybackController : BaseController
 
     [HttpGet]
     [Route("music/play")]
-    async public Task<ActionResult> Play(string id, string provider, string audio_provider, string stream_mode, string playback_mode, string title, string artist_name, string album_title, int? duration_ms, string date, string isrc)
+    async public Task<ActionResult> Play(string id, string provider, string audio_provider, string stream_mode, string playback_mode, string title, string artist_name, string album_id, string album_title, int? duration_ms, string date, string isrc)
     {
         string profileId = MusicProfileIdentity.Resolve(requestInfo, Request);
-        var track = await MusicPlaybackService.ResolveRequestTrackAsync(id, provider, title, artist_name, album_title, duration_ms, date, isrc);
+        var track = await MusicPlaybackService.ResolveRequestTrackAsync(id, provider, title, artist_name, album_id, album_title, duration_ms, date, isrc);
         var result = await MusicPlaybackService.ResolveTrackAsync(track, audio_provider, stream_mode, playback_mode, profileId, HttpContext.RequestAborted);
         MusicPlaybackService.PrepareStreamSources(host, track, provider, audio_provider, stream_mode, playback_mode, result);
         return ContentTo(MusicJson.Serialize(result));
@@ -62,7 +62,7 @@ public class PlaybackController : BaseController
 
     [HttpGet]
     [Route("music/stream")]
-    async public Task<ActionResult> Stream(string ticket, string id, string provider, string audio_provider, string quality, string stream_mode, string playback_mode, string title, string artist_name, string album_title, int? duration_ms, string date, string isrc)
+    async public Task<ActionResult> Stream(string ticket, string id, string provider, string audio_provider, string quality, string stream_mode, string playback_mode, string title, string artist_name, string album_id, string album_title, int? duration_ms, string date, string isrc)
     {
         if (MusicStreamTicketService.TryGet(ticket, out var ticketSource))
         {
@@ -75,7 +75,7 @@ public class PlaybackController : BaseController
         }
 
         string profileId = MusicProfileIdentity.Resolve(requestInfo, Request);
-        var track = await MusicPlaybackService.ResolveRequestTrackAsync(id, provider, title, artist_name, album_title, duration_ms, date, isrc);
+        var track = await MusicPlaybackService.ResolveRequestTrackAsync(id, provider, title, artist_name, album_id, album_title, duration_ms, date, isrc);
         // upstream-ссылка умерла (403/410/416 в relay) — кэш sources для этого
         // трека может держать те же мёртвые URL: пере-резолв идёт с refreshSources
         var result = await MusicPlaybackService.ResolveTrackAsync(track, audio_provider, stream_mode, playback_mode, profileId, HttpContext.RequestAborted, refreshSources: true);
@@ -92,13 +92,27 @@ public class PlaybackController : BaseController
 
     [HttpPost]
     [Route("music/history/mark")]
-    async public Task<ActionResult> MarkHistory(string id, string provider, string title, string artist_name, string album_title, int? duration_ms, string date, string isrc, bool count_play = false, long? played_ms = null)
+    async public Task<ActionResult> MarkHistory(string id, string provider, string title, string artist_name, string album_id, string album_title, int? duration_ms, string date, string isrc, bool count_play = false, long? played_ms = null, string image = null)
     {
-        var track = await MusicPlaybackService.ResolveRequestTrackAsync(id, provider, title, artist_name, album_title, duration_ms, date, isrc);
+        var track = await MusicPlaybackService.ResolveRequestTrackAsync(id, provider, title, artist_name, album_id, album_title, duration_ms, date, isrc);
         string profileId = MusicProfileIdentity.Resolve(requestInfo, Request);
 
         if (track != null)
         {
+            image = image?.Trim();
+            if (image?.StartsWith("//", StringComparison.Ordinal) == true)
+                image = "https:" + image;
+
+            if (track.images?.Any(i => !string.IsNullOrWhiteSpace(i?.url)) != true
+                && !string.IsNullOrWhiteSpace(image) && image.Length <= 8192
+                && Uri.TryCreate(image, UriKind.Absolute, out var imageUri)
+                && (imageUri.Scheme == Uri.UriSchemeHttp || imageUri.Scheme == Uri.UriSchemeHttps))
+            {
+                // Client artwork belongs to this history entry, not the shared metadata cache.
+                track = MusicJson.Deserialize<MusicTrack>(MusicJson.Serialize(track));
+                track.images = new List<MusicImage> { new() { url = imageUri.AbsoluteUri } };
+            }
+
             await MusicPlaybackHistoryService.SaveAsync(profileId, track);
 
             // статистику инкрементим только по честному прослушиванию:

--- a/Modules/Music/Providers/Discovery/Spotify/SpotifyDiscoveryProvider.cs
+++ b/Modules/Music/Providers/Discovery/Spotify/SpotifyDiscoveryProvider.cs
@@ -167,7 +167,7 @@ public class SpotifyDiscoveryProvider : IMusicDiscoveryProvider
 
     public async Task<List<MusicBrowseSection>> GetHomeSectionsAsync(int limit, CancellationToken cancellationToken = default)
     {
-        var section = await BuildSectionAsync(cancellationToken);
+        var section = await BuildSectionAsync(limit, cancellationToken);
         return section == null ? new List<MusicBrowseSection>() : new List<MusicBrowseSection> { section };
     }
 
@@ -177,7 +177,7 @@ public class SpotifyDiscoveryProvider : IMusicDiscoveryProvider
         if (!string.Equals(sectionId, BuildSectionId(profile.country), StringComparison.OrdinalIgnoreCase))
             return null;
 
-        return await BuildSectionAsync(cancellationToken);
+        return await BuildSectionAsync(limit, cancellationToken);
     }
 
     public static bool IsPlaylistAlbum(string provider, string id)
@@ -199,17 +199,19 @@ public class SpotifyDiscoveryProvider : IMusicDiscoveryProvider
         return album == null ? null : CopyAlbum(album, playlist.title, includeTracks: true);
     }
 
-    async Task<MusicBrowseSection> BuildSectionAsync(CancellationToken cancellationToken)
+    async Task<MusicBrowseSection> BuildSectionAsync(int limit, CancellationToken cancellationToken)
     {
         var profile = GetProfile();
-        var tasks = profile.playlists.Select(item => LoadPlaylistAsync(item.playlistId, 1, cancellationToken)).ToList();
+        int take = Math.Clamp(limit, 1, profile.playlists.Count);
+        var playlists = profile.playlists.Take(take).ToList();
+        var tasks = playlists.Select(item => LoadPlaylistAsync(item.playlistId, 1, cancellationToken)).ToList();
         var results = await Task.WhenAll(tasks);
         var albums = new List<MusicAlbum>();
 
-        for (int i = 0; i < profile.playlists.Count; i++)
+        for (int i = 0; i < playlists.Count; i++)
         {
             if (results[i] != null)
-                albums.Add(CopyAlbum(results[i], profile.playlists[i].title, includeTracks: false));
+                albums.Add(CopyAlbum(results[i], playlists[i].title, includeTracks: false));
         }
 
         if (albums.Count == 0)
@@ -221,7 +223,7 @@ public class SpotifyDiscoveryProvider : IMusicDiscoveryProvider
             title = profile.title,
             type = "album",
             source_provider = SpotifySupport.DiscoveryProviderId,
-            has_more = false,
+            has_more = profile.playlists.Count > take,
             albums = albums
         };
     }

--- a/Modules/Music/Providers/Discovery/YouTubeMusic/YouTubeMusicSearchSupport.cs
+++ b/Modules/Music/Providers/Discovery/YouTubeMusic/YouTubeMusicSearchSupport.cs
@@ -25,7 +25,12 @@ internal static class YouTubeMusicSearchSupport
 
     public static bool IsSearchEnabled => ModInit.conf?.youtube_audio_enabled == true;
 
-    public static async Task<List<MusicTrack>> SearchTracksByQueryAsync(string query, int limit = 10, CancellationToken cancellationToken = default)
+    public static async Task<List<MusicTrack>> SearchTracksByQueryAsync(
+        string query,
+        int limit = 10,
+        CancellationToken cancellationToken = default,
+        string expectedArtist = null,
+        bool requireAuthorMatch = false)
     {
         if (string.IsNullOrWhiteSpace(query))
             return new List<MusicTrack>();
@@ -56,7 +61,9 @@ internal static class YouTubeMusicSearchSupport
             }
 
             return videos
-                .Select(MapTrack)
+                .Where(video => !requireAuthorMatch
+                    || SameArtist(CleanArtist(video.Author.ChannelTitle), expectedArtist))
+                .Select(video => MapTrack(video, expectedArtist))
                 .Where(i => i != null)
                 .Take(Math.Max(1, limit))
                 .ToList();
@@ -261,7 +268,7 @@ internal static class YouTubeMusicSearchSupport
         yield return query;
     }
 
-    static MusicTrack MapTrack(VideoSearchResult video)
+    static MusicTrack MapTrack(VideoSearchResult video, string expectedArtist = null)
     {
         string videoId = video?.Id.Value;
         string rawTitle = video?.Title?.Trim();
@@ -273,6 +280,24 @@ internal static class YouTubeMusicSearchSupport
         string title = CleanTitle(rawTitle, artist, out var titleArtist);
         if (string.IsNullOrWhiteSpace(artist))
             artist = titleArtist;
+
+        // Artist-pool search knows which artist it requested. This resolves
+        // both common upload formats (Artist - Title and Title - Artist)
+        // without guessing in the generic recommendation normalizer.
+        if (!string.IsNullOrWhiteSpace(expectedArtist)
+            && TrySplitTitleSides(rawTitle, out var left, out var right))
+        {
+            if (SameArtist(left, expectedArtist))
+            {
+                artist = expectedArtist.Trim();
+                title = StripTitleNoise(right);
+            }
+            else if (SameArtist(right, expectedArtist))
+            {
+                artist = expectedArtist.Trim();
+                title = StripTitleNoise(left);
+            }
+        }
 
         return new MusicTrack
         {
@@ -287,6 +312,28 @@ internal static class YouTubeMusicSearchSupport
                 new() { provider = ProviderId, external_id = videoId }
             }
         };
+    }
+
+    static bool TrySplitTitleSides(string rawTitle, out string left, out string right)
+    {
+        left = null;
+        right = null;
+
+        if (string.IsNullOrWhiteSpace(rawTitle))
+            return false;
+
+        foreach (var separator in titleSeparators)
+        {
+            var parts = rawTitle.Split(separator, 2, StringSplitOptions.TrimEntries);
+            if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
+                continue;
+
+            left = parts[0];
+            right = parts[1];
+            return true;
+        }
+
+        return false;
     }
 
     static MusicAlbum MapPlaylist(PlaylistSearchResult playlist)

--- a/Modules/Music/Providers/Metadata/MusicBrainz/MusicBrainzMetadataProvider.cs
+++ b/Modules/Music/Providers/Metadata/MusicBrainz/MusicBrainzMetadataProvider.cs
@@ -7,6 +7,7 @@ namespace Music;
 public class MusicBrainzMetadataProvider : IMusicMetadataProvider
 {
     static readonly HttpClient httpClient = MusicHttp.CreateClient("musicbrainz");
+    static readonly TimeSpan requestTimeout = TimeSpan.FromSeconds(20);
     static readonly SemaphoreSlim requestGate = new(1, 1);
     static DateTime nextRequestAt = DateTime.MinValue;
 
@@ -19,7 +20,7 @@ public class MusicBrainzMetadataProvider : IMusicMetadataProvider
 
     static MusicBrainzMetadataProvider()
     {
-        httpClient.Timeout = TimeSpan.FromSeconds(20);
+        httpClient.Timeout = requestTimeout;
     }
 
     public async Task<MusicSearchResult> SearchAsync(string query, bool expanded = false, CancellationToken cancellationToken = default)
@@ -192,20 +193,46 @@ public class MusicBrainzMetadataProvider : IMusicMetadataProvider
         if (string.IsNullOrWhiteSpace(path))
             return null;
 
-        await RespectRateLimitAsync(cancellationToken);
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(requestTimeout);
+        var token = timeoutCts.Token;
+        long started = System.Diagnostics.Stopwatch.GetTimestamp();
 
         try
         {
-            using var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}/{path}");
-            request.Headers.TryAddWithoutValidation("User-Agent", userAgent);
-            request.Headers.TryAddWithoutValidation("Accept", "application/json");
+            for (int attempt = 0; attempt < 2; attempt++)
+            {
+                await RespectRateLimitAsync(token);
 
-            using var response = await httpClient.SendAsync(request, cancellationToken);
-            if (!response.IsSuccessStatusCode)
-                return null;
+                TimeSpan delay;
+                using (var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}/{path}"))
+                {
+                    request.Headers.TryAddWithoutValidation("User-Agent", userAgent);
+                    request.Headers.TryAddWithoutValidation("Accept", "application/json");
 
-            var json = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonNode.Parse(json) as JsonObject;
+                    using var response = await httpClient.SendAsync(request, token);
+                    if (response.IsSuccessStatusCode)
+                    {
+                        var json = await response.Content.ReadAsStringAsync(token);
+                        return JsonNode.Parse(json) as JsonObject;
+                    }
+
+                    if (attempt != 0 || (int)response.StatusCode is not (429 or 502 or 503 or 504))
+                        return null;
+
+                    var retryAfter = response.Headers.RetryAfter;
+                    delay = retryAfter?.Delta
+                        ?? (retryAfter?.Date is DateTimeOffset retryAt ? retryAt - DateTimeOffset.UtcNow : TimeSpan.Zero);
+                    if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+                }
+
+                // Never shorten Retry-After or give the retry a fresh timeout budget.
+                var remaining = requestTimeout - System.Diagnostics.Stopwatch.GetElapsedTime(started);
+                if (delay >= remaining) return null;
+                if (delay > TimeSpan.Zero) await Task.Delay(delay, token);
+            }
+
+            return null;
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {

--- a/Modules/Music/Providers/SoundCloud/SoundCloudSupport.Catalog.cs
+++ b/Modules/Music/Providers/SoundCloud/SoundCloudSupport.Catalog.cs
@@ -826,9 +826,8 @@ public static partial class SoundCloudSupport
         if (string.IsNullOrWhiteSpace(title))
             return null;
 
-        string artistName = titleParts.artist;
-        if (track.TryGetProperty("user", out var user) && user.ValueKind == JsonValueKind.Object)
-            artistName ??= GetString(user, "username")?.Trim();
+        var artists = ExtractCandidateArtists(track);
+        string artistName = artists.FirstOrDefault();
 
         string artwork = UpgradeArtwork(GetString(track, "artwork_url")) ?? fallbackArtwork;
         string permalinkUrl = GetString(track, "permalink_url");
@@ -1348,9 +1347,8 @@ public static partial class SoundCloudSupport
         if (string.IsNullOrWhiteSpace(title))
             return null;
 
-        string artistName = titleParts.artist;
-        if (track.TryGetProperty("user", out var user) && user.ValueKind == JsonValueKind.Object)
-            artistName ??= GetString(user, "username")?.Trim();
+        var artists = ExtractCandidateArtists(track);
+        string artistName = artists.FirstOrDefault();
 
         string artwork = UpgradeArtwork(GetString(track, "artwork_url"));
         string permalinkUrl = GetString(track, "permalink_url");

--- a/Modules/Music/Providers/Spotify/SpotifySupport.cs
+++ b/Modules/Music/Providers/Spotify/SpotifySupport.cs
@@ -12,6 +12,14 @@ namespace Music;
 // аудио резолвится обычным конвейером (YouTube-матчер), как у VK-чарта.
 public static class SpotifySupport
 {
+    public sealed class ArtistDiscoveryResult
+    {
+        public string artist_id { get; set; }
+        public string artist_name { get; set; }
+        public List<MusicTrack> top_tracks { get; set; } = new();
+        public List<MusicArtist> related_artists { get; set; } = new();
+    }
+
     public const string ProviderId = "spotify";
     public const string DiscoveryProviderId = "spotifycharts";
     public const string PlaylistSourceType = "spotify_playlist";
@@ -190,9 +198,10 @@ public static class SpotifySupport
 
                 var album = GetProperty(data.Value, "albumOfTrack");
                 string albumTitle = album != null ? GetString(album.Value, "name") : null;
+                string albumId = album != null ? GetString(album.Value, "uri") : null;
                 var images = album != null ? MapCoverArt(GetProperty(album.Value, "coverArt")) : null;
 
-                var mapped = MapTrackElement(data.Value, albumTitle, images, date: null, durationProperty: "duration");
+                var mapped = MapTrackElement(data.Value, albumTitle, images, date: null, durationProperty: "duration", albumId: albumId);
                 if (mapped != null)
                     tracks.Add(mapped);
 
@@ -413,6 +422,62 @@ public static class SpotifySupport
         catch { return new List<MusicArtist>(); }
     }
 
+    // Лёгкий discovery-ответ для персональных миксов: один queryArtist
+    // без загрузки всей дискографии, которую делает GetArtistAsync.
+    public static async Task<ArtistDiscoveryResult> GetArtistDiscoveryByNameAsync(
+        string query,
+        int topTrackLimit = 12,
+        int relatedArtistLimit = 12,
+        CancellationToken cancellationToken = default)
+    {
+        var candidates = await SearchArtistsAsync(query, 5, cancellationToken);
+        var artist = candidates.FirstOrDefault(candidate => MusicMapSupport.IsAliasOf(candidate?.name, query));
+        if (artist == null)
+            return null;
+
+        return await GetArtistDiscoveryAsync(artist.id, topTrackLimit, relatedArtistLimit, cancellationToken);
+    }
+
+    public static async Task<ArtistDiscoveryResult> GetArtistDiscoveryAsync(
+        string artistId,
+        int topTrackLimit = 12,
+        int relatedArtistLimit = 12,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(artistId)
+            || !artistId.StartsWith("spotify:artist:", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        try
+        {
+            var root = await QueryV2Async("queryArtist", QueryArtistHash, new { uri = artistId }, cancellationToken);
+            var artist = GetProperty(root, "data", "artistUnion");
+            if (artist == null || artist.Value.ValueKind != JsonValueKind.Object)
+                return null;
+
+            string name = GetString(GetProperty(artist.Value, "profile") ?? default, "name")?.Trim();
+            if (string.IsNullOrWhiteSpace(name))
+                return null;
+
+            var discography = GetProperty(artist.Value, "discography");
+            var related = GetProperty(artist.Value, "relatedContent");
+
+            return new ArtistDiscoveryResult
+            {
+                artist_id = artistId,
+                artist_name = name,
+                top_tracks = discography == null
+                    ? new List<MusicTrack>()
+                    : MapTopTracks(GetProperty(discography.Value, "topTracks"), Math.Clamp(topTrackLimit, 1, 30)),
+                related_artists = related == null
+                    ? new List<MusicArtist>()
+                    : MapRelatedArtists(GetProperty(related.Value, "relatedArtists"), Math.Clamp(relatedArtistLimit, 1, 30))
+            };
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+        catch { return null; }
+    }
+
     // Альбомы для Spotify-вкладки поиска (findTopResults -> searchV2.albumsV2).
     public static async Task<List<MusicAlbum>> SearchAlbumsAsync(string query, int limit, CancellationToken cancellationToken = default)
     {
@@ -586,6 +651,7 @@ public static class SpotifySupport
                     var mapped = MapTrackElement(track.Value, title, images, date, durationProperty: "duration");
                     if (mapped != null)
                     {
+                        mapped.album_id = id;
                         mapped.album_title = title;
                         album.tracks.Add(mapped);
                     }
@@ -753,9 +819,10 @@ public static class SpotifySupport
 
             var album = GetProperty(track.Value, "albumOfTrack");
             string albumTitle = album != null ? GetString(album.Value, "name") : null;
+            string albumId = album != null ? GetString(album.Value, "uri") : null;
             var images = album != null ? MapCoverArt(GetProperty(album.Value, "coverArt")) : null;
 
-            var mapped = MapTrackElement(track.Value, albumTitle, images, date: null, durationProperty: "duration");
+            var mapped = MapTrackElement(track.Value, albumTitle, images, date: null, durationProperty: "duration", albumId: albumId);
             if (mapped != null)
                 result.Add(mapped);
 
@@ -1185,7 +1252,13 @@ public static class SpotifySupport
                 if (track == null)
                     continue;
 
-                var mapped = MapTrackElement(track.Value, title, albumImages, date, durationProperty: "duration");
+                var mapped = MapTrackElement(
+                    track.Value,
+                    title,
+                    albumImages,
+                    date,
+                    durationProperty: "duration",
+                    albumId: $"spotify:album:{albumId}");
                 if (mapped != null)
                     tracks.Add(mapped);
             }
@@ -1225,12 +1298,13 @@ public static class SpotifySupport
 
         var album = GetProperty(data.Value, "albumOfTrack");
         string albumTitle = album != null ? GetString(album.Value, "name") : null;
+        string albumId = album != null ? GetString(album.Value, "uri") : null;
         var images = album != null ? MapCoverArt(GetProperty(album.Value, "coverArt")) : null;
 
-        return MapTrackElement(data.Value, albumTitle, images, date: null, durationProperty: "trackDuration");
+        return MapTrackElement(data.Value, albumTitle, images, date: null, durationProperty: "trackDuration", albumId: albumId);
     }
 
-    static MusicTrack MapTrackElement(JsonElement track, string albumTitle, List<MusicImage> images, string date, string durationProperty)
+    static MusicTrack MapTrackElement(JsonElement track, string albumTitle, List<MusicImage> images, string date, string durationProperty, string albumId = null)
     {
         string title = GetString(track, "name")?.Trim();
         string uri = GetString(track, "uri");
@@ -1246,6 +1320,7 @@ public static class SpotifySupport
             title = title,
             artist_name = artists.Count > 0 ? string.Join(", ", artists) : "Spotify",
             artists = artists,
+            album_id = string.IsNullOrWhiteSpace(albumId) ? null : albumId.Trim(),
             album_title = string.IsNullOrWhiteSpace(albumTitle) ? null : albumTitle.Trim(),
             duration_ms = duration != null ? GetInt(duration.Value, "totalMilliseconds") : null,
             track_number = GetInt(track, "trackNumber"),

--- a/Modules/Music/Services/Cache/MusicMetadataCacheService.cs
+++ b/Modules/Music/Services/Cache/MusicMetadataCacheService.cs
@@ -10,7 +10,14 @@ public static class MusicMetadataCacheService
     // полный TTL превращал его в залипшее «ничего не найдено»
     static readonly TimeSpan emptyTtl = TimeSpan.FromMinutes(20);
 
-    public static async Task<T> GetOrCreateAsync<T>(string providerId, string entityType, string cacheKey, TimeSpan ttl, Func<Task<T>> factory, CancellationToken cancellationToken = default) where T : class
+    public static async Task<T> GetOrCreateAsync<T>(
+        string providerId,
+        string entityType,
+        string cacheKey,
+        TimeSpan ttl,
+        Func<Task<T>> factory,
+        CancellationToken cancellationToken = default,
+        Func<T, TimeSpan> ttlSelector = null) where T : class
     {
         var cached = await GetAsync<T>(providerId, entityType, cacheKey, cancellationToken);
         if (cached != null)
@@ -18,7 +25,13 @@ public static class MusicMetadataCacheService
 
         var created = await factory();
         if (created != null)
-            await SaveAsync(providerId, entityType, cacheKey, created, IsEmptyPayload(created) ? emptyTtl : ttl, cancellationToken);
+        {
+            TimeSpan selectedTtl = IsEmptyPayload(created)
+                ? emptyTtl
+                : ttlSelector?.Invoke(created) ?? ttl;
+
+            await SaveAsync(providerId, entityType, cacheKey, created, selectedTtl, cancellationToken);
+        }
 
         return created;
     }

--- a/Modules/Music/Services/Catalog/MusicCatalogService.cs
+++ b/Modules/Music/Services/Catalog/MusicCatalogService.cs
@@ -24,7 +24,9 @@ public static class MusicCatalogService
     // v35: уточнённые Spotify release labels для singles/EP/appears-on.
     // v36: Spotify singles/EP отдаются как track-section, не album-section.
     // v37: track metadata сохраняет ISRC для точного audio matching.
-    const string metadataCacheVersion = "v37";
+    // v38: Spotify tracks сохраняют album_id для быстрого нативного
+    // разрешения длительности без ошибочного fallback в MusicBrainz.
+    const string metadataCacheVersion = "v38";
     static readonly object homeWarmLock = new();
     static readonly Dictionary<string, Task<List<MusicBrowseSection>>> homeWarmTasks = new(StringComparer.OrdinalIgnoreCase);
 
@@ -190,15 +192,22 @@ public static class MusicCatalogService
                 () => SpotifySupport.GetArtistAsync(id, cancellationToken), cancellationToken);
 
         var metadata = MusicProviderRegistry.GetMetadataProvider(provider);
+        bool isMusicBrainz = metadata is MusicBrainzMetadataProvider;
         return metadata == null
             ? Task.FromResult<MusicArtist>(null)
             : MusicMetadataCacheService.GetOrCreateAsync(
                 metadata.Id,
                 "artist",
-                VersionedKey(id),
+                // Bypass old week-long empty discographies without invalidating other caches.
+                VersionedKey(isMusicBrainz ? $"artist-discography:v2:{id}" : id),
                 artistCacheTtl,
                 () => metadata.GetArtistAsync(id, cancellationToken),
-                cancellationToken
+                cancellationToken,
+                ttlSelector: artist => isMusicBrainz
+                    && (artist.albums?.Count ?? 0) == 0
+                    && (artist.sections?.Count ?? 0) == 0
+                        ? TimeSpan.FromMinutes(20)
+                        : artistCacheTtl
             );
     }
 
@@ -472,34 +481,22 @@ public static class MusicCatalogService
         if (artists.Count > 0)
             sections.Add(new MusicBrowseSection
             {
-                id = SpotifySupport.ArtistsSectionId,
-                title = "Исполнители",
-                type = "artists",
-                source_provider = SpotifySupport.ProviderId,
-                has_more = false,
-                artists = artists
+                id = SpotifySupport.ArtistsSectionId, title = "Исполнители", type = "artists",
+                source_provider = SpotifySupport.ProviderId, has_more = false, artists = artists
             });
 
         if (albums.Count > 0)
             sections.Add(new MusicBrowseSection
             {
-                id = SpotifySupport.AlbumsSectionId,
-                title = "Альбомы",
-                type = "albums",
-                source_provider = SpotifySupport.ProviderId,
-                has_more = false,
-                albums = albums
+                id = SpotifySupport.AlbumsSectionId, title = "Альбомы", type = "albums",
+                source_provider = SpotifySupport.ProviderId, has_more = false, albums = albums
             });
 
         if (tracks.Count > 0)
             sections.Add(new MusicBrowseSection
             {
-                id = SpotifySupport.TracksSectionId,
-                title = "Треки",
-                type = "tracks",
-                source_provider = SpotifySupport.ProviderId,
-                has_more = false,
-                tracks = tracks
+                id = SpotifySupport.TracksSectionId, title = "Треки", type = "tracks",
+                source_provider = SpotifySupport.ProviderId, has_more = false, tracks = tracks
             });
 
         return sections;
@@ -507,7 +504,11 @@ public static class MusicCatalogService
 
     static bool ShouldSkipMetadataTrackLookup(string id, string provider)
     {
-        if (StartsWithAny(id, "inline:", "youtube:", "sefon:", "soundcloud:"))
+        // Spotify здесь является каталогом/источником discovery, но не
+        // IMusicMetadataProvider. Без этого gate GetMetadataProvider("spotify")
+        // откатывается на дефолтный MusicBrainz и до его сетевого таймаута
+        // пытается найти там spotify:track:* перед каждым первым запуском.
+        if (StartsWithAny(id, "inline:", "youtube:", "sefon:", "soundcloud:", "spotify:"))
             return true;
 
         return !string.IsNullOrWhiteSpace(provider)

--- a/Modules/Music/Services/Images/MusicImageProxyService.cs
+++ b/Modules/Music/Services/Images/MusicImageProxyService.cs
@@ -125,6 +125,13 @@ public static class MusicImageProxyService
             return album;
 
         ProxyImages(controller, album.images);
+
+        if (album.tracks != null)
+        {
+            foreach (var track in album.tracks)
+                Apply(controller, track);
+        }
+
         return album;
     }
 
@@ -172,6 +179,10 @@ public static class MusicImageProxyService
         {
             if (image == null || string.IsNullOrWhiteSpace(image.url))
                 continue;
+
+            // Normalize even when image proxying is disabled (e.g. file:// TV clients).
+            if (image.url.StartsWith("//", StringComparison.Ordinal))
+                image.url = "https:" + image.url;
 
             // кэши секций/сущностей шарят инстансы между запросами, а Apply
             // мутирует url на месте — хост ПЕРВОГО запросившего запекался в

--- a/Modules/Music/Services/Playback/MusicDailyMixService.cs
+++ b/Modules/Music/Services/Playback/MusicDailyMixService.cs
@@ -6,10 +6,9 @@ namespace Music;
 /// «Миксы недели»: каждому дню недели детерминированно назначаются два
 /// артиста из истории прослушиваний профиля + до двух похожих (доминирующие
 /// чужие артисты из SoundCloud related-пулов) — это основа микса. Поверх —
-/// ЕДИНЫЙ слой открытий с общим бюджетом 5 треков (строго additive, в слотах
-/// не анонсируется): приоритет у внешних артистов с Music-Map (по 2 трека),
-/// остаток добирает жанр дня (популярное канонического SC-жанра от совсем
-/// незнакомых артистов); открытия вплетаются в микс равномерно. Seed =
+/// Поверх — additive discovery-слой: Music-Map, SoundCloud-жанры и
+/// Spotify related artists делят до 8 слотов с адаптивными квотами;
+/// открытия вплетаются в микс равномерно. Seed =
 /// profile + ISO-неделя, поэтому внутри дня и недели состав стабилен, а на
 /// следующей неделе раскладка меняется. Сводки по дням — чистый SQL без
 /// внешних HTTP; треки грузятся лениво при открытии микса.
@@ -18,6 +17,7 @@ public static class MusicDailyMixService
 {
     static readonly TimeSpan mixTimeout = TimeSpan.FromSeconds(8);
     static readonly TimeSpan mixCacheTtl = TimeSpan.FromHours(12);
+    static readonly TimeSpan shortMixCacheTtl = TimeSpan.FromMinutes(30);
     const int historyDepth = 150;
     const int ownArtistsPerDay = 2;
     const int minHistoryArtists = 3;
@@ -37,18 +37,23 @@ public static class MusicDailyMixService
     const int maxExternalArtists = 2;
     const int maxRefillExternalArtists = 6;
     const int externalPickWindow = 12;
-    // ЕДИНЫЙ бюджет «открытий» (ревью Codex): Music-Map externals + жанровые
-    // треки делят 5 слотов на микс, приоритет у Music-Map, жанр добирает
-    // остаток; иначе микс рискует стать «слишком не твоим»
-    const int discoveryTrackBudget = 5;
+    // Music-Map + жанр сохраняют свои прежние 5 слотов. Spotify related
+    // получает до 4 слотов, но общий discovery-слой ограничен 8:
+    // источники адаптивно забирают незанятые места, но не вытесняют основу.
+    const int coreDiscoveryTrackBudget = 5;
+    const int discoveryTrackBudget = 8;
+    const int spotifyTrackQuota = 4;
     const int desiredMixTrackCount = 20;
     const int maxMainTracksPerArtist = 4;
     const int maxDiscoveryTracksPerArtist = 2;
     const int externalPoolCandidateLimit = 10;
     const int genreTrackQuota = 4;
     const int genrePoolFetchLimit = 30;
+    const int spotifyFallbackTarget = 16;
+    const int spotifyRelatedArtistLimit = 2;
     static readonly TimeSpan genreCacheTtl = TimeSpan.FromHours(6);
     static readonly TimeSpan artistGenresCacheTtl = TimeSpan.FromDays(14);
+    static readonly TimeSpan spotifyDiscoveryCacheTtl = TimeSpan.FromDays(7);
     // кэш собранных кандидатов недели (история + парс payload всех плейлистов —
     // самая дорогая часть /music/home). Сбор НЕ зависит от недели и salt (они
     // входят только в шаффл), поэтому ключ — профиль; сброс миксов и смена
@@ -62,6 +67,16 @@ public static class MusicDailyMixService
     // кап жёсткий: чтение lock-free, trim + вставка под общим lock — иначе
     // параллельные сборы одновременно пройдут проверку Count и вместе её пробьют
     static readonly object seedArtistsCacheWriteLock = new();
+    // v19-target-20: расширенный discovery-слой не раздувает итог выше целевых 20
+    // v18-spotify-peer: Spotify related участвует во всех миксах с адаптивной квотой 2–4
+    // v17-spotify-buckets: фиты Spotify считаются по primary artist и не обходят cap
+    // v16-spotify-fallback: короткие миксы добираются чистой Spotify
+    // metadata сидов, затем максимум двух related artists, только до 16
+    // v15-short-ttl: миксы короче 16 треков живут в кэше 30m, а не 12h
+    // v14-secondary-genre: один дополнительный жанр добирает только
+    // короткие (<16) миксы; обычные миксы и HTTP-бюджет не меняются
+    // v13-metadata: неразрушающая нормализация + подтверждение Music-Map
+    // external через YouTube author-match либо SoundCloud ISRC
     // v12: основной artist-cap снижен до 4 треков, чтобы якорь не доминировал
     // в 20-трековом миксе; v11: короткие миксы после artist-cap добираются дополнительными
     // Music-Map/genre артистами до ~20 треков без снятия лимитов на артиста;
@@ -71,7 +86,9 @@ public static class MusicDailyMixService
     // v8: artist-pool теперь гейтит кандидатов по запрошенному артисту и
     // канонизирует uploader/channel-имена; v7 — title-prefix нормализация сидов
     // применяется и к истории (YouTube/SC channel/uploader -> реальный Artist - Title)
-    const string cacheVersion = "dailymix-v12";
+    // v20: пересобираем миксы с album_id из Spotify, чтобы playback мог
+    // быстро получить точную длительность без обращения к MusicBrainz.
+    const string cacheVersion = "dailymix-v20-spotify-album-id";
 
     static readonly string[] dayTitles =
     {
@@ -93,6 +110,18 @@ public static class MusicDailyMixService
         public int Count;
         public int FirstIndex;
         public int NoisyCount;
+    }
+
+    sealed class GenrePoolPlan
+    {
+        public List<List<MusicTrack>> PrimaryPools { get; init; } = new();
+        public string SecondaryGenre { get; init; }
+    }
+
+    sealed class SpotifyDiscoveryPlan
+    {
+        public List<SpotifySupport.ArtistDiscoveryResult> SeedDiscoveries { get; init; } = new();
+        public List<List<MusicTrack>> RelatedPools { get; init; } = new();
     }
 
     // кэшируемый payload микса; null из фабрики (слабый результат) не кэшируется
@@ -162,7 +191,8 @@ public static class MusicDailyMixService
                 cacheKey,
                 mixCacheTtl,
                 () => BuildMixAsync(profileId, day, salt, seeds, historyArtists, cancellationToken),
-                cancellationToken);
+                cancellationToken,
+                created => created.tracks.Count < 16 ? shortMixCacheTtl : mixCacheTtl);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -551,6 +581,10 @@ public static class MusicDailyMixService
         if (pools.Count == 0)
             return null;
 
+        // сэмплирование внутри дня тоже детерминировано: пул может обновиться
+        // (6h TTL radio-кэша), а микс дня не должен скакать между заходами
+        uint sampleSeed = Fnv1aHash($"{NormalizeProfileKey(profileId)}|{SeedKey(salt)}|{day}|tracks");
+
         // Music-Map — только additive-слой. Запускаем его после проверки, что
         // базовый микс уже есть: так при пустых artist/related-пулах не остаются
         // фоновые HTTP-задачи, а общий 8-секундный бюджет всё равно сохраняется.
@@ -562,11 +596,13 @@ public static class MusicDailyMixService
         // (жанры артистов кэшируются 14d, пул жанра — 6h)
         var genrePoolsTask = SoundCloudSupport.IsDiscoveryEnabled
             ? LoadGenrePoolsAsync(seeds, timeoutCts.Token)
-            : Task.FromResult(new List<List<MusicTrack>>());
+            : Task.FromResult(new GenrePoolPlan());
 
-        // сэмплирование внутри дня тоже детерминировано: пул может обновиться
-        // (6h TTL radio-кэша), а микс дня не должен скакать между заходами
-        uint sampleSeed = Fnv1aHash($"{NormalizeProfileKey(profileId)}|{SeedKey(salt)}|{day}|tracks");
+        // Spotify стартует параллельно с другим discovery. На холодном кэше
+        // это не добавляет последовательную задержку к сборке микса.
+        var spotifyDiscoveryTask = ModInit.conf?.spotify_discovery_enabled == true
+            ? LoadSpotifyDiscoveryPlanAsync(seeds, mixArtists, sampleSeed, timeoutCts.Token)
+            : Task.FromResult(new SpotifyDiscoveryPlan());
 
         for (int i = 0; i < pools.Count; i++)
         {
@@ -608,12 +644,12 @@ public static class MusicDailyMixService
 
             if (externalPools.Count > 0)
                 MusicRadioService.FillRoundRobin(
-                    externalPools, discoveryOutput, discoveryTrackBudget,
+                    externalPools, discoveryOutput, coreDiscoveryTrackBudget,
                     strictNoisyWords, requireCyrillic,
                     excludedIds, excludedKeys, excludedTitles, outputIds, outputKeys, outputTitles,
                     discoveryArtistCounts, maxDiscoveryTracksPerArtist);
 
-            int remaining = Math.Min(discoveryTrackBudget - discoveryOutput.Count, genreTrackQuota);
+            int remaining = Math.Min(coreDiscoveryTrackBudget - discoveryOutput.Count, genreTrackQuota);
 
             if (remaining > 0)
             {
@@ -631,6 +667,25 @@ public static class MusicDailyMixService
                         excludedIds, excludedKeys, excludedTitles, outputIds, outputKeys, outputTitles,
                         discoveryArtistCounts);
             }
+
+            var spotifyPlan = await spotifyDiscoveryTask;
+            int spotifyLimit = Math.Min(
+                discoveryTrackBudget,
+                discoveryOutput.Count + spotifyTrackQuota);
+
+            FillSpotifyRelatedPools(
+                spotifyPlan.RelatedPools,
+                discoveryOutput,
+                spotifyLimit,
+                strictNoisyWords,
+                requireCyrillic,
+                discoveryArtistCounts,
+                excludedIds,
+                excludedKeys,
+                excludedTitles,
+                outputIds,
+                outputKeys,
+                outputTitles);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -645,7 +700,9 @@ public static class MusicDailyMixService
         MusicRadioService.FillRoundRobin(
             pools,
             output,
-            mixTrackLimit - discoveryOutput.Count,
+            Math.Min(
+                mixTrackLimit - discoveryOutput.Count,
+                desiredMixTrackCount - discoveryOutput.Count),
             seedNoisyWords,
             requireCyrillic,
             excludedIds,
@@ -676,6 +733,7 @@ public static class MusicDailyMixService
                 requireCyrillic,
                 discoveryOutput,
                 desiredDiscoveryLimit,
+                output.Count,
                 discoveryArtistCounts,
                 excludedIds,
                 excludedKeys,
@@ -685,6 +743,32 @@ public static class MusicDailyMixService
                 outputTitles,
                 genrePools,
                 timeoutCts.Token);
+        }
+
+        if (ModInit.conf?.spotify_discovery_enabled == true
+            && output.Count + discoveryOutput.Count < spotifyFallbackTarget
+            && desiredDiscoveryLimit > discoveryOutput.Count)
+        {
+            await FillSpotifyFallbackAsync(
+                spotifyDiscoveryTask,
+                seeds,
+                mixArtists,
+                sampleSeed,
+                seedNoisyWords,
+                strictNoisyWords,
+                requireCyrillic,
+                discoveryOutput,
+                desiredDiscoveryLimit,
+                output.Count,
+                mainArtistCounts,
+                discoveryArtistCounts,
+                excludedIds,
+                excludedKeys,
+                excludedTitles,
+                outputIds,
+                outputKeys,
+                outputTitles,
+                cancellationToken);
         }
 
         // открытия вплетаются равномерно, а не хвостом:
@@ -713,7 +797,7 @@ public static class MusicDailyMixService
     // артиста остаются теми же, поэтому микс растёт шириной, а не повтором.
     static async Task RefillShortMixAsync(
         List<Task<List<string>>> musicMapTasks,
-        Task<List<List<MusicTrack>>> genrePoolsTask,
+        Task<GenrePoolPlan> genrePoolsTask,
         List<HistoryArtist> seeds,
         List<HistoryArtist> historyArtists,
         List<string> mixArtists,
@@ -724,6 +808,7 @@ public static class MusicDailyMixService
         bool requireCyrillic,
         List<MusicTrack> discoveryOutput,
         int desiredDiscoveryLimit,
+        int mainTrackCount,
         Dictionary<string, int> discoveryArtistCounts,
         HashSet<string> excludedIds,
         HashSet<string> excludedKeys,
@@ -785,14 +870,32 @@ public static class MusicDailyMixService
                 genrePools = await PrepareGenrePoolsAsync(genrePoolsTask, knownNames, sampleSeed, cancellationToken);
             }
 
-            if (genrePools.Count == 0)
+            if (genrePools.Count > 0)
+                FillDiscoveryFromGenrePools(
+                    genrePools, discoveryOutput, desiredDiscoveryLimit,
+                    strictNoisyWords, requireCyrillic,
+                    excludedIds, excludedKeys, excludedTitles, outputIds, outputKeys, outputTitles,
+                    discoveryArtistCounts);
+
+            if (mainTrackCount + discoveryOutput.Count >= 16
+                || desiredDiscoveryLimit <= discoveryOutput.Count)
                 return;
 
-            FillDiscoveryFromGenrePools(
-                genrePools, discoveryOutput, desiredDiscoveryLimit,
-                strictNoisyWords, requireCyrillic,
-                excludedIds, excludedKeys, excludedTitles, outputIds, outputKeys, outputTitles,
-                discoveryArtistCounts);
+            var secondaryGenrePools = await PrepareGenrePoolsAsync(
+                genrePoolsTask,
+                historyArtists.Select(i => i.Name)
+                    .Concat(mixArtists)
+                    .Concat(selectedExternalArtists),
+                sampleSeed + 0x6A09E667,
+                cancellationToken,
+                secondary: true);
+
+            if (secondaryGenrePools.Count > 0)
+                FillDiscoveryFromGenrePools(
+                    secondaryGenrePools, discoveryOutput, desiredDiscoveryLimit,
+                    strictNoisyWords, requireCyrillic,
+                    excludedIds, excludedKeys, excludedTitles, outputIds, outputKeys, outputTitles,
+                    discoveryArtistCounts);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -811,7 +914,7 @@ public static class MusicDailyMixService
     static async Task<List<List<MusicTrack>>> LoadExternalArtistPoolsAsync(List<string> artists, CancellationToken cancellationToken)
     {
         var poolTasks = artists
-            .Select(artist => MusicRadioService.LoadArtistPoolAsync(artist, cancellationToken))
+            .Select(artist => MusicRadioService.LoadArtistPoolAsync(artist, cancellationToken, requireConfirmedArtist: true))
             .ToList();
 
         try
@@ -828,6 +931,256 @@ public static class MusicDailyMixService
             .Where(pool => pool.Count > 0)
             .Select(pool => pool.Take(externalPoolCandidateLimit).ToList())
             .ToList();
+    }
+
+    static async Task FillSpotifyFallbackAsync(
+        Task<SpotifyDiscoveryPlan> spotifyDiscoveryTask,
+        List<HistoryArtist> seeds,
+        List<string> mixArtists,
+        uint sampleSeed,
+        HashSet<string> seedNoisyWords,
+        HashSet<string> strictNoisyWords,
+        bool requireCyrillic,
+        List<MusicTrack> discoveryOutput,
+        int desiredDiscoveryLimit,
+        int mainTrackCount,
+        Dictionary<string, int> mainArtistCounts,
+        Dictionary<string, int> discoveryArtistCounts,
+        HashSet<string> excludedIds,
+        HashSet<string> excludedKeys,
+        HashSet<string> excludedTitles,
+        HashSet<string> outputIds,
+        HashSet<string> outputKeys,
+        HashSet<string> outputTitles,
+        CancellationToken cancellationToken)
+    {
+        int missing = spotifyFallbackTarget - mainTrackCount - discoveryOutput.Count;
+        if (missing <= 0)
+            return;
+
+        int target = Math.Min(desiredDiscoveryLimit, discoveryOutput.Count + missing);
+
+        try
+        {
+            SpotifyDiscoveryPlan plan = null;
+            try
+            {
+                plan = await spotifyDiscoveryTask;
+            }
+            catch
+            {
+            }
+
+            if (plan == null)
+            {
+                using var retryCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                retryCts.CancelAfter(TimeSpan.FromSeconds(6));
+                plan = await LoadSpotifyDiscoveryPlanAsync(seeds, mixArtists, sampleSeed, retryCts.Token);
+            }
+
+            var seedDiscoveries = plan.SeedDiscoveries;
+
+            var seedPools = seedDiscoveries
+                .Select(item => item.top_tracks
+                    .Select(MusicRadioService.NormalizeCandidateMetadata)
+                    .Where(track => track != null)
+                    .ToList())
+                .Where(pool => pool.Count > 0)
+                .ToList();
+
+            for (int i = 0; i < seedPools.Count; i++)
+                ShuffleDeterministic(seedPools[i], sampleSeed + 0x3C6EF372 + (uint)i);
+
+            if (seedPools.Count > 0)
+            {
+                MusicRadioService.FillRoundRobin(
+                    seedPools, discoveryOutput, target,
+                    seedNoisyWords, requireCyrillic,
+                    excludedIds, excludedKeys, excludedTitles, outputIds, outputKeys, outputTitles,
+                    mainArtistCounts, maxMainTracksPerArtist);
+
+                if (mainTrackCount + discoveryOutput.Count < spotifyFallbackTarget && requireCyrillic)
+                    MusicRadioService.FillRoundRobin(
+                        seedPools, discoveryOutput, target,
+                        seedNoisyWords, false,
+                        excludedIds, excludedKeys, excludedTitles, outputIds, outputKeys, outputTitles,
+                        mainArtistCounts, maxMainTracksPerArtist);
+            }
+
+            if (mainTrackCount + discoveryOutput.Count >= spotifyFallbackTarget
+                || discoveryOutput.Count >= target)
+                return;
+
+            FillSpotifyRelatedPools(
+                plan.RelatedPools,
+                discoveryOutput,
+                target,
+                strictNoisyWords,
+                requireCyrillic,
+                discoveryArtistCounts,
+                excludedIds,
+                excludedKeys,
+                excludedTitles,
+                outputIds,
+                outputKeys,
+                outputTitles);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+        }
+    }
+
+    static async Task<SpotifyDiscoveryPlan> LoadSpotifyDiscoveryPlanAsync(
+        List<HistoryArtist> seeds,
+        IEnumerable<string> mixArtists,
+        uint sampleSeed,
+        CancellationToken cancellationToken)
+    {
+        var seedTasks = seeds.Select(seed => LoadSpotifyArtistDiscoveryByNameAsync(seed.Name, cancellationToken)).ToList();
+
+        try
+        {
+            await Task.WhenAll(seedTasks);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+        }
+
+        var seedDiscoveries = seedTasks
+            .Where(task => task.IsCompletedSuccessfully && task.Result != null)
+            .Select(task => task.Result)
+            .ToList();
+
+        if (seedDiscoveries.Count == 0)
+            return new SpotifyDiscoveryPlan();
+
+        var excludedNames = seeds.Select(seed => seed.Name)
+            .Concat(mixArtists ?? Enumerable.Empty<string>())
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .ToList();
+
+        var relatedCandidates = seedDiscoveries
+            .SelectMany(discovery => discovery.related_artists.Select((artist, rank) => new { artist, rank }))
+            .Where(item => item.artist != null
+                && !string.IsNullOrWhiteSpace(item.artist.id)
+                && !string.IsNullOrWhiteSpace(item.artist.name)
+                && !excludedNames.Any(name => MusicMapSupport.IsAliasOf(item.artist.name, name)))
+            .GroupBy(item => MusicRadioService.NormalizeText(item.artist.name), StringComparer.Ordinal)
+            .Where(group => !string.IsNullOrWhiteSpace(group.Key))
+            .Select(group => new
+            {
+                artist = group.First().artist,
+                sources = group.Count(),
+                rank = group.Min(item => item.rank)
+            })
+            .OrderByDescending(item => item.sources)
+            .ThenBy(item => item.rank)
+            .Take(8)
+            .ToList();
+
+        // Совпадение related от обоих сидов важнее позиции в одном списке.
+        // Внутри одинаковой силы порядок зависит от seed дня.
+        ShuffleDeterministic(relatedCandidates, sampleSeed + 0xBB67AE85);
+        var selectedRelated = relatedCandidates
+            .OrderByDescending(item => item.sources)
+            .Take(spotifyRelatedArtistLimit)
+            .Select(item => item.artist)
+            .ToList();
+
+        var relatedTasks = selectedRelated
+            .Select(artist => LoadSpotifyArtistDiscoveryByIdAsync(artist.id, cancellationToken))
+            .ToList();
+
+        try
+        {
+            await Task.WhenAll(relatedTasks);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+        }
+
+        var relatedPools = relatedTasks
+            .Where(task => task.IsCompletedSuccessfully && task.Result != null)
+            .Select(task => task.Result.top_tracks
+                .Select(MusicRadioService.NormalizeCandidateMetadata)
+                .Where(track => track != null)
+                .ToList())
+            .Where(pool => pool.Count > 0)
+            .ToList();
+
+        for (int i = 0; i < relatedPools.Count; i++)
+            ShuffleDeterministic(relatedPools[i], sampleSeed + 0xA54FF53A + (uint)i);
+
+        return new SpotifyDiscoveryPlan
+        {
+            SeedDiscoveries = seedDiscoveries,
+            RelatedPools = relatedPools
+        };
+    }
+
+    static void FillSpotifyRelatedPools(
+        List<List<MusicTrack>> relatedPools,
+        List<MusicTrack> discoveryOutput,
+        int limit,
+        HashSet<string> strictNoisyWords,
+        bool requireCyrillic,
+        Dictionary<string, int> discoveryArtistCounts,
+        HashSet<string> excludedIds,
+        HashSet<string> excludedKeys,
+        HashSet<string> excludedTitles,
+        HashSet<string> outputIds,
+        HashSet<string> outputKeys,
+        HashSet<string> outputTitles)
+    {
+        if (relatedPools == null || relatedPools.Count == 0 || discoveryOutput.Count >= limit)
+            return;
+
+        MusicRadioService.FillRoundRobin(
+            relatedPools, discoveryOutput, limit,
+            strictNoisyWords, requireCyrillic,
+            excludedIds, excludedKeys, excludedTitles, outputIds, outputKeys, outputTitles,
+            discoveryArtistCounts, maxDiscoveryTracksPerArtist);
+
+        if (discoveryOutput.Count < limit && requireCyrillic)
+            MusicRadioService.FillRoundRobin(
+                relatedPools, discoveryOutput, limit,
+                strictNoisyWords, false,
+                excludedIds, excludedKeys, excludedTitles, outputIds, outputKeys, outputTitles,
+                discoveryArtistCounts, maxDiscoveryTracksPerArtist);
+    }
+
+    static Task<SpotifySupport.ArtistDiscoveryResult> LoadSpotifyArtistDiscoveryByNameAsync(string artist, CancellationToken cancellationToken)
+    {
+        return MusicMetadataCacheService.GetOrCreateAsync(
+            SpotifySupport.ProviderId,
+            "weekly_artist_discovery",
+            $"artist-name-v2|{MusicRadioService.NormalizeText(artist)}",
+            spotifyDiscoveryCacheTtl,
+            () => SpotifySupport.GetArtistDiscoveryByNameAsync(artist, cancellationToken: cancellationToken),
+            cancellationToken);
+    }
+
+    static Task<SpotifySupport.ArtistDiscoveryResult> LoadSpotifyArtistDiscoveryByIdAsync(string artistId, CancellationToken cancellationToken)
+    {
+        return MusicMetadataCacheService.GetOrCreateAsync(
+            SpotifySupport.ProviderId,
+            "weekly_artist_discovery",
+            $"artist-id-v2|{artistId}",
+            spotifyDiscoveryCacheTtl,
+            () => SpotifySupport.GetArtistDiscoveryAsync(artistId, cancellationToken: cancellationToken),
+            cancellationToken);
     }
 
     // общий для main-заполнения и refill: жанровый слой в два прохода —
@@ -865,16 +1218,33 @@ public static class MusicDailyMixService
     }
 
     static async Task<List<List<MusicTrack>>> PrepareGenrePoolsAsync(
-        Task<List<List<MusicTrack>>> genrePoolsTask,
+        Task<GenrePoolPlan> genrePoolsTask,
         IEnumerable<string> knownNames,
         uint sampleSeed,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool secondary = false)
     {
         List<List<MusicTrack>> source;
 
         try
         {
-            source = await genrePoolsTask ?? new List<List<MusicTrack>>();
+            var plan = await genrePoolsTask ?? new GenrePoolPlan();
+
+            if (!secondary)
+            {
+                source = plan.PrimaryPools;
+            }
+            else if (!string.IsNullOrWhiteSpace(plan.SecondaryGenre))
+            {
+                var secondaryPool = await LoadGenrePoolAsync(plan.SecondaryGenre, cancellationToken);
+                source = secondaryPool.Count > 0
+                    ? new List<List<MusicTrack>> { secondaryPool }
+                    : new List<List<MusicTrack>>();
+            }
+            else
+            {
+                source = new List<List<MusicTrack>>();
+            }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -909,7 +1279,7 @@ public static class MusicDailyMixService
     // жанра (кэш 6h). Жанр берётся только ПРИ УВЕРЕННОСТИ (ревью Codex):
     // явный победитель — один пул; ничья двух сильных жанров (артисты дня
     // из разных миров) — слой делится между обоими; слабый сигнал — слоя нет
-    static async Task<List<List<MusicTrack>>> LoadGenrePoolsAsync(List<HistoryArtist> seeds, CancellationToken cancellationToken)
+    static async Task<GenrePoolPlan> LoadGenrePoolsAsync(List<HistoryArtist> seeds, CancellationToken cancellationToken)
     {
         var genreTasks = seeds.Select(seed => MusicMetadataCacheService.GetOrCreateAsync(
             SoundCloudSupport.DiscoveryProviderId,
@@ -950,7 +1320,7 @@ public static class MusicDailyMixService
 
         // слабый сигнал: жанр не был топ-тегом ни одного артиста (score < 3)
         if (ranked.Count == 0 || ranked[0].Value < 3)
-            return new List<List<MusicTrack>>();
+            return new GenrePoolPlan();
 
         var chosenGenres = new List<string> { ranked[0].Key };
 
@@ -959,13 +1329,15 @@ public static class MusicDailyMixService
         if (ranked.Count > 1 && ranked[1].Value >= 3 && ranked[1].Value * 2 > ranked[0].Value)
             chosenGenres.Add(ranked[1].Key);
 
-        var poolTasks = chosenGenres.Select(genre => MusicMetadataCacheService.GetOrCreateAsync(
-            SoundCloudSupport.DiscoveryProviderId,
-            "genre_tracks",
-            $"genrepool-v1|{genre}",
-            genreCacheTtl,
-            () => SoundCloudSupport.SearchTracksByGenreAsync(genre, genrePoolFetchLimit, cancellationToken),
-            cancellationToken)).ToList();
+        // Пул не грузим заранее: он нужен только если после обычного
+        // добора микс остался короче 16 треков. Берём ровно один следующий
+        // жанр и только при реальном сигнале от сидов (score >= 2).
+        string secondaryGenre = ranked
+            .Where(item => item.Value >= 2 && !chosenGenres.Contains(item.Key, StringComparer.OrdinalIgnoreCase))
+            .Select(item => item.Key)
+            .FirstOrDefault();
+
+        var poolTasks = chosenGenres.Select(genre => LoadGenrePoolAsync(genre, cancellationToken)).ToList();
 
         try
         {
@@ -979,11 +1351,26 @@ public static class MusicDailyMixService
         {
         }
 
-        return poolTasks
-            .Where(task => task.IsCompletedSuccessfully)
-            .Select(task => task.Result ?? new List<MusicTrack>())
-            .Where(pool => pool.Count > 0)
-            .ToList();
+        return new GenrePoolPlan
+        {
+            PrimaryPools = poolTasks
+                .Where(task => task.IsCompletedSuccessfully)
+                .Select(task => task.Result ?? new List<MusicTrack>())
+                .Where(pool => pool.Count > 0)
+                .ToList(),
+            SecondaryGenre = secondaryGenre
+        };
+    }
+
+    static Task<List<MusicTrack>> LoadGenrePoolAsync(string genre, CancellationToken cancellationToken)
+    {
+        return MusicMetadataCacheService.GetOrCreateAsync(
+            SoundCloudSupport.DiscoveryProviderId,
+            "genre_tracks",
+            $"genrepool-v1|{genre}",
+            genreCacheTtl,
+            () => SoundCloudSupport.SearchTracksByGenreAsync(genre, genrePoolFetchLimit, cancellationToken),
+            cancellationToken);
     }
 
     // внешние похожие артисты с Music-Map: пересечение карт обоих сид-артистов

--- a/Modules/Music/Services/Playback/MusicPlaybackService.cs
+++ b/Modules/Music/Services/Playback/MusicPlaybackService.cs
@@ -4,10 +4,32 @@ namespace Music;
 
 public static class MusicPlaybackService
 {
-    public static async Task<MusicTrack> ResolveRequestTrackAsync(string id, string provider, string title, string artistName, string albumTitle, int? durationMs, string date, string isrc)
+    public static async Task<MusicTrack> ResolveRequestTrackAsync(string id, string provider, string title, string artistName, string albumId, string albumTitle, int? durationMs, string date, string isrc)
     {
         string normalizedIsrc = MusicIsrc.Normalize(isrc);
-        var track = await MusicCatalogService.GetTrackAsync(id, provider);
+        MusicTrack track = null;
+
+        // Spotify search отдаёт точный track/album id, но без duration/isrc.
+        // Достаём трек из его родного queryAlbum (кэшируется каталогом), вместо
+        // заведомо бесполезного поиска spotify:track:* через MusicBrainz.
+        if (!string.IsNullOrWhiteSpace(id)
+            && id.StartsWith("spotify:track:", StringComparison.OrdinalIgnoreCase)
+            && !durationMs.HasValue
+            && !string.IsNullOrWhiteSpace(albumId)
+            && albumId.StartsWith("spotify:album:", StringComparison.OrdinalIgnoreCase))
+        {
+            var albumTask = MusicCatalogService.GetAlbumAsync(albumId, SpotifySupport.ProviderId);
+            if (await Task.WhenAny(albumTask, Task.Delay(2500)) == albumTask)
+            {
+                var album = await albumTask;
+                track = album?.tracks?.FirstOrDefault(i => string.Equals(i?.id, id, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+        else
+        {
+            track = await MusicCatalogService.GetTrackAsync(id, provider);
+        }
+
         if (track != null)
         {
             track.isrc = MusicIsrc.Normalize(track.isrc) ?? normalizedIsrc;
@@ -22,6 +44,7 @@ public static class MusicPlaybackService
             id = string.IsNullOrWhiteSpace(id) ? BuildInlineTrackId(title, artistName, albumTitle, durationMs, normalizedIsrc) : id,
             title = title,
             artist_name = artistName,
+            album_id = albumId,
             album_title = albumTitle,
             isrc = normalizedIsrc,
             duration_ms = durationMs,
@@ -132,6 +155,9 @@ public static class MusicPlaybackService
 
         if (!string.IsNullOrWhiteSpace(track?.artist_name))
             url.Add($"artist_name={Uri.EscapeDataString(track.artist_name)}");
+
+        if (!string.IsNullOrWhiteSpace(track?.album_id))
+            url.Add($"album_id={Uri.EscapeDataString(track.album_id)}");
 
         if (!string.IsNullOrWhiteSpace(track?.album_title))
             url.Add($"album_title={Uri.EscapeDataString(track.album_title)}");

--- a/Modules/Music/Services/Playback/MusicRadioService.cs
+++ b/Modules/Music/Services/Playback/MusicRadioService.cs
@@ -11,7 +11,7 @@ public static class MusicRadioService
     const int maxSeedArtists = 5;
     const int providerQueryLimit = 12;
     const int maxPoolPerArtist = 24;
-    const string cacheVersion = "radio-v2";
+    const string cacheVersion = "radio-v3-metadata";
 
     public static async Task<MusicRadioResponse> GetAsync(string profileId, MusicRadioRequest request, int limit = 20, CancellationToken cancellationToken = default)
     {
@@ -192,7 +192,11 @@ public static class MusicRadioService
 
     static string BuildArtistBucketKey(MusicTrack track)
     {
-        string artist = CleanupArtistName(track?.artist_name);
+        // Структурированный список хранит primary artist первым. Иначе
+        // "Artist, Guest" и "Artist" попадают в разные bucket'ы и обходят artist-cap.
+        string artist = CleanupArtistName(track?.artists?.FirstOrDefault());
+        if (string.IsNullOrWhiteSpace(artist))
+            artist = CleanupArtistName(track?.artist_name);
         return string.IsNullOrWhiteSpace(artist)
             ? string.Empty
             : MusicMapSupport.NormalizeName(artist);
@@ -301,23 +305,34 @@ public static class MusicRadioService
             cacheLimit: maxPoolPerArtist);
     }
 
-    internal static async Task<List<MusicTrack>> LoadArtistPoolAsync(string artist, CancellationToken cancellationToken)
+    internal static async Task<List<MusicTrack>> LoadArtistPoolAsync(
+        string artist,
+        CancellationToken cancellationToken,
+        bool requireConfirmedArtist = false)
     {
         var tasks = new List<Task<List<MusicTrack>>>();
+        string cacheType = requireConfirmedArtist ? "radio_tracks_confirmed" : "radio_tracks";
 
         if (YouTubeMusicSearchSupport.IsSearchEnabled)
             tasks.Add(LoadCachedTracksAsync(
                 YouTubeMusicSearchSupport.ProviderId,
                 artist,
-                token => YouTubeMusicSearchSupport.SearchTracksByQueryAsync(artist, providerQueryLimit, token),
-                cancellationToken));
+                token => YouTubeMusicSearchSupport.SearchTracksByQueryAsync(
+                    artist,
+                    providerQueryLimit,
+                    token,
+                    artist,
+                    requireConfirmedArtist),
+                cancellationToken,
+                cacheType));
 
         if (SoundCloudSupport.IsDiscoveryEnabled)
             tasks.Add(LoadCachedTracksAsync(
                 SoundCloudSupport.DiscoveryProviderId,
                 artist,
                 token => SoundCloudSupport.SearchTracksByQueryAsync(artist, providerQueryLimit, token),
-                cancellationToken));
+                cancellationToken,
+                cacheType));
 
         if (tasks.Count == 0)
             return new List<MusicTrack>();
@@ -330,16 +345,30 @@ public static class MusicRadioService
         {
         }
 
-        return tasks
+        var candidates = tasks
             .Where(i => i.IsCompletedSuccessfully)
             .SelectMany(i => i.Result ?? new List<MusicTrack>())
-            .Select(track => NormalizeArtistPoolCandidate(track, artist))
+            .Select(track => NormalizeArtistPoolCandidate(track, artist, !requireConfirmedArtist))
             .Where(i => i != null)
             .Take(maxPoolPerArtist)
             .ToList();
+
+        if (requireConfirmedArtist && !candidates.Any(IsConfirmedExternalArtistEvidence))
+            return new List<MusicTrack>();
+
+        return candidates;
     }
 
-    static MusicTrack NormalizeArtistPoolCandidate(MusicTrack track, string requestedArtist)
+    static bool IsConfirmedExternalArtistEvidence(MusicTrack track)
+    {
+        if ((track?.id ?? string.Empty).StartsWith("youtube:", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return (track?.id ?? string.Empty).StartsWith("soundcloud:", StringComparison.OrdinalIgnoreCase)
+            && MusicIsrc.Normalize(track.isrc) != null;
+    }
+
+    static MusicTrack NormalizeArtistPoolCandidate(MusicTrack track, string requestedArtist, bool allowTitlePrefix)
     {
         track = NormalizeCandidateMetadata(track);
         string artist = CleanupArtistName(requestedArtist);
@@ -371,7 +400,9 @@ public static class MusicRadioService
             return track;
         }
 
-        if (!string.IsNullOrWhiteSpace(title) && title.StartsWith(requested + " ", StringComparison.OrdinalIgnoreCase))
+        if (allowTitlePrefix
+            && !string.IsNullOrWhiteSpace(title)
+            && title.StartsWith(requested + " ", StringComparison.OrdinalIgnoreCase))
         {
             track.artist_name = artist;
             track.artists = new List<string> { artist };
@@ -484,16 +515,35 @@ public static class MusicRadioService
 
     internal static MusicTrack NormalizeCandidateMetadata(MusicTrack track)
     {
-        if (track == null || string.IsNullOrWhiteSpace(track.title))
+        if (track == null)
             return track;
 
-        if (!TrySplitArtistTitle(track.title, out var artist, out var title))
-            return track;
+        // Provider/cache objects can be reused by radio and weekly mixes. Never
+        // rewrite those shared instances while preparing one response.
+        var result = CloneTrack(track);
+        result.title = CleanupCandidateTitle(result.title);
 
-        track.artist_name = artist;
-        track.artists = new List<string> { artist };
-        track.title = title;
-        return track;
+        if (string.IsNullOrWhiteSpace(result.title)
+            || !TrySplitArtistTitle(result.title, out var artist, out var title))
+        {
+            return result;
+        }
+
+        string currentArtist = CleanupArtistName(result.artist_name);
+        if (!string.IsNullOrWhiteSpace(currentArtist)
+            && !IsGenericUploaderName(currentArtist)
+            && !ArtistNamesMatch(currentArtist, artist))
+        {
+            // Structured provider metadata is more trustworthy than an
+            // unverified multi-dash title. Keeping it intact also preserves an
+            // exact provider id for playback instead of inventing a new pair.
+            return result;
+        }
+
+        result.artist_name = artist;
+        result.artists = new List<string> { artist };
+        result.title = CleanupCandidateTitle(title);
+        return result;
     }
 
     static bool TrySplitArtistTitle(string rawTitle, out string artist, out string title)
@@ -501,16 +551,14 @@ public static class MusicRadioService
         artist = null;
         title = null;
 
-        var parts = Regex.Split(rawTitle ?? string.Empty, @"\s+[-–—]\s+")
-            .Select(i => i.Trim())
-            .Where(i => !string.IsNullOrWhiteSpace(i))
-            .ToList();
-
-        if (parts.Count < 2)
+        var match = Regex.Match(
+            rawTitle ?? string.Empty,
+            @"^\s*(?<artist>.{2,80}?)\s+[-–—]\s+(?<title>.{2,180})\s*$");
+        if (!match.Success)
             return false;
 
-        string artistPart = parts[^2];
-        string titlePart = parts[^1];
+        string artistPart = match.Groups["artist"].Value;
+        string titlePart = match.Groups["title"].Value;
 
         artistPart = Regex.Replace(artistPart, @"^\s*[\d#._-]+\s*", "").Trim();
         titlePart = Regex.Replace(titlePart, @"^\s*[\d#._-]+\s*", "").Trim();
@@ -527,6 +575,63 @@ public static class MusicRadioService
         artist = artistPart;
         title = titlePart;
         return true;
+    }
+
+    static bool ArtistNamesMatch(string left, string right)
+    {
+        string a = NormalizeText(CleanupArtistName(left));
+        string b = NormalizeText(CleanupArtistName(right));
+
+        return !string.IsNullOrWhiteSpace(a)
+            && !string.IsNullOrWhiteSpace(b)
+            && (a == b
+                || (a.Length >= 4 && b.Contains(a, StringComparison.Ordinal))
+                || (b.Length >= 4 && a.Contains(b, StringComparison.Ordinal)));
+    }
+
+    static bool IsGenericUploaderName(string value)
+    {
+        string normalized = NormalizeText(value);
+        return normalized is "soundcloud" or "youtube" or "unknown" or "various artists";
+    }
+
+    static string CleanupCandidateTitle(string value)
+    {
+        value = Regex.Replace(value ?? string.Empty, @"\s+", " ").Trim();
+        if (string.IsNullOrWhiteSpace(value))
+            return value;
+
+        bool filename = Regex.IsMatch(value, @"\.(aac|flac|m4a|mp3|ogg|opus|wav|webm)\s*$", RegexOptions.IgnoreCase);
+        if (!filename)
+            return value;
+
+        value = Regex.Replace(value, @"\.(aac|flac|m4a|mp3|ogg|opus|wav|webm)\s*$", string.Empty, RegexOptions.IgnoreCase);
+        value = Regex.Replace(value, @"_+", " ");
+        value = Regex.Replace(value, @"^\s*[-–—.]+\s*|\s*[-–—.]+\s*$", string.Empty);
+        return Regex.Replace(value, @"\s+", " ").Trim();
+    }
+
+    static MusicTrack CloneTrack(MusicTrack track)
+    {
+        return new MusicTrack
+        {
+            id = track.id,
+            title = track.title,
+            artist_id = track.artist_id,
+            artist_name = track.artist_name,
+            artists = track.artists?.ToList() ?? new List<string>(),
+            album_id = track.album_id,
+            album_title = track.album_title,
+            isrc = track.isrc,
+            duration_ms = track.duration_ms,
+            track_number = track.track_number,
+            disc_number = track.disc_number,
+            date = track.date,
+            search_score = track.search_score,
+            images = track.images?.ToList() ?? new List<MusicImage>(),
+            provider_refs = track.provider_refs?.ToList() ?? new List<MusicProviderRef>(),
+            auto_radio = track.auto_radio
+        };
     }
 
     static bool LooksLikeStandaloneSong(MusicTrack track, string titleKey, HashSet<string> seedNoisyWords, bool requireCyrillic)

--- a/Modules/Music/plugin.js
+++ b/Modules/Music/plugin.js
@@ -187,6 +187,7 @@
     };
     var MUSIC_RADIO_STATE = {
         pending: false,
+        request: null,
         lastGeneration: '',
         lastRequestAt: 0
     };
@@ -478,9 +479,9 @@
         }
     }
 
-    function request(url, success, error) {
+    function request(url, success, error, timeoutMs) {
         var network = new Lampa.Reguest();
-        network.timeout(20000);
+        network.timeout(Math.max(1000, Number(timeoutMs || 20000)));
         network.silent(withIdentity(url), success, error || function () {});
     }
 
@@ -1215,6 +1216,7 @@
         name = name || 'content';
 
         setTimeout(function () {
+            if (isStandaloneIosPlayerForeground()) return;
             try {
                 if (Lampa.Controller && Lampa.Controller.toggle)
                     Lampa.Controller.toggle(name);
@@ -1303,12 +1305,14 @@
         if (!context) return;
 
         setTimeout(function () {
+            if (isStandaloneIosPlayerForeground()) return;
             if (Date.now() < MUSIC_HOME_REFRESH_RESTORE_BLOCK_UNTIL && context.container && $(context.container).hasClass('lm-home-line'))
                 return;
 
             restoreController(context.controller || 'content');
 
             setTimeout(function () {
+                if (isStandaloneIosPlayerForeground()) return;
                 var target = findMusicFocusElement(context);
                 if (!target) {
                     var fallbackContainer = context.container && document.documentElement.contains(context.container)
@@ -2057,6 +2061,7 @@
         if (track && getTrackProviderId(track)) parts.push('provider=' + encodeURIComponent(getTrackProviderId(track)));
         if (track && track.title) parts.push('title=' + encodeURIComponent(track.title));
         if (track && track.artist_name) parts.push('artist_name=' + encodeURIComponent(track.artist_name));
+        if (track && track.album_id) parts.push('album_id=' + encodeURIComponent(track.album_id));
         if (track && track.album_title) parts.push('album_title=' + encodeURIComponent(track.album_title));
         if (track && track.isrc) parts.push('isrc=' + encodeURIComponent(track.isrc));
         if (track && (track.duration_ms || track.duration_ms === 0)) parts.push('duration_ms=' + encodeURIComponent(track.duration_ms));
@@ -2801,6 +2806,12 @@
     }
 
     function emitRecentChanged(sectionKey, payload) {
+        // History is saved during playback; rebuilding shelves must wait until the player yields focus.
+        if (isStandaloneIosPlayerForeground()) {
+            MUSIC_DEFERRED_HOME_REFRESH = true;
+            return;
+        }
+
         if (isLampaPlayerOverlayOpen()) {
             MUSIC_DEFERRED_HOME_REFRESH = true;
             traceEmbeddedIos('recent-event-deferred', sectionKey || '', true);
@@ -2814,6 +2825,25 @@
                 payload: payload || null
             }
         }));
+    }
+
+    function isStandaloneIosPlayerForeground() {
+        return MUSIC_IOS_FULL_PLAYER_OPEN
+            || !!(MUSIC_IOS_BAR && MUSIC_IOS_BAR.hasClass('lm-ios-player--visible')
+                && safeControllerName() === 'lampac_music_player_bar');
+    }
+
+    function flushStandaloneIosDeferredHomeRefresh() {
+        if (!MUSIC_DEFERRED_HOME_REFRESH || isStandaloneIosPlayerForeground() || isLampaPlayerOverlayOpen()) return;
+
+        var controller = safeControllerName();
+        if (controller !== 'content' && controller !== 'items_line') return;
+
+        var active = Lampa.Activity.active();
+        if (!active || active.component !== 'lampac_music_home') return;
+
+        // Controller.toggle restores navigation only; Activity.toggle also consumes the pending home refresh.
+        if (active.activity && typeof active.activity.toggle === 'function') active.activity.toggle();
     }
 
     function isLampaPlayerOverlayOpen() {
@@ -3764,7 +3794,7 @@
     function getActiveMusicQuery() {
         try {
             var active = Lampa.Activity.active();
-            if (!active || active.component !== 'lampac_music_home') return '';
+            if (!active || (active.component !== 'lampac_music_home' && active.component !== 'lampac_music_search')) return '';
             return String(active.query || '').trim();
         } catch (e) {
             return '';
@@ -4382,9 +4412,77 @@
         Lampa.Storage.set(MUSIC.storage.radio_autoplay_enabled, enabled === true);
 
         if (!enabled) {
-            MUSIC_RADIO_STATE.pending = false;
+            resetRadioAutoplayRequest();
             MUSIC_RADIO_STATE.lastGeneration = '';
         }
+    }
+
+    function resetRadioAutoplayRequest() {
+        var request = MUSIC_RADIO_STATE.request;
+        if (request) {
+            ['play', 'seeking', 'error'].forEach(function (type) {
+                request.media.removeEventListener(type, request.onIntent);
+            });
+        }
+        MUSIC_RADIO_STATE.request = null;
+        MUSIC_RADIO_STATE.pending = false;
+    }
+
+    function cancelRadioAutoplayResume() {
+        var request = MUSIC_RADIO_STATE.request;
+        if (request && request.waiting) {
+            request.waiting = null;
+            request.resumeCancelled = true;
+        }
+    }
+
+    function radioQueueIdentity(tracks) {
+        // Snapshot IDs change on saves, even when the playback queue is unchanged.
+        return JSON.stringify((tracks || []).map(function (track) { return track && track.id || ''; }));
+    }
+
+    function isRadioAutoplayRequestCurrent(request) {
+        if (!request || MUSIC_RADIO_STATE.request !== request || !isRadioAutoplayEnabled()
+            || getPlaybackMode() !== 'audio' || getStandaloneIosRepeatMode() === 'all'
+            || request.player !== currentExternalPlayer() || request.launch !== MUSIC_PLAY_LAUNCH_TOKEN
+            || request.queue !== radioQueueIdentity(queueTracks())) return false;
+
+        if (shouldUseStandaloneIosAudio())
+            return isStandaloneIosAudioActive() && request.media === MUSIC_IOS_AUDIO.audio;
+
+        var data = activePlayerData();
+        return !!(data && data.from_music_cluster && request.media === activeMusicMediaElement()
+            && canReuseActiveQueue(queueTracks()));
+    }
+
+    function waitForRadioAutoplay(media) {
+        var request = MUSIC_RADIO_STATE.request;
+        if (!isRadioAutoplayRequestCurrent(request) || request.media !== media
+            || request.resumeCancelled || getStandaloneIosRepeatMode() !== 'off' || media.error) return false;
+
+        var standalone = shouldUseStandaloneIosAudio();
+        var index = queueCurrentIndex();
+        if (index < 0 || (standalone ? standaloneIosNeighborIndex(1) >= 0 : index < queueTracks().length - 1))
+            return false;
+
+        request.waiting = {
+            index: index,
+            time: Number(media.currentTime || 0),
+            source: media.currentSrc || media.src,
+            switchToken: standalone ? MUSIC_IOS_AUDIO.playWatchToken : MUSIC_EMBEDDED_IOS.switchToken
+        };
+        return true;
+    }
+
+    function canResumeRadioAutoplay(request) {
+        var waiting = request.waiting;
+        var media = request.media;
+        var switchToken = shouldUseStandaloneIosAudio() ? MUSIC_IOS_AUDIO.playWatchToken : MUSIC_EMBEDDED_IOS.switchToken;
+        return !!(waiting && getStandaloneIosRepeatMode() === 'off' && !media.error
+            && (media.paused || media.ended) && queueCurrentIndex() === waiting.index
+            && (!shouldUseStandaloneIosAudio() || standaloneIosNeighborIndex(1) < 0)
+            && switchToken === waiting.switchToken && (media.currentSrc || media.src) === waiting.source
+            && Math.abs(Number(media.currentTime || 0) - waiting.time) < 0.5);
     }
 
     function normalizeRadioDedupeText(value) {
@@ -4510,12 +4608,14 @@
         if (shouldUseStandaloneIosAudio()) {
             if (!isStandaloneIosAudioActive()) return 0;
 
+            var order = isStandaloneIosShuffle() ? standaloneIosOrder().slice() : null;
             additions.forEach(function (track) {
+                if (order) order.push(MUSIC_IOS_AUDIO.tracks.length);
                 MUSIC_IOS_AUDIO.tracks.push(track);
                 MUSIC_IOS_AUDIO.playlist.push(buildPlayback(track));
             });
 
-            MUSIC_IOS_AUDIO.shuffleOrder = null;
+            MUSIC_IOS_AUDIO.shuffleOrder = order;
             MUSIC_QUEUE.tracks = MUSIC_IOS_AUDIO.tracks.slice();
             MUSIC_QUEUE.currentIndex = MUSIC_IOS_AUDIO.currentIndex;
             MUSIC_QUEUE.currentTrackId = MUSIC_IOS_AUDIO.tracks[MUSIC_IOS_AUDIO.currentIndex]
@@ -4593,6 +4693,28 @@
         if (!generation || MUSIC_RADIO_STATE.pending || MUSIC_RADIO_STATE.lastGeneration === generation)
             return;
 
+        var media = shouldUseStandaloneIosAudio() ? MUSIC_IOS_AUDIO.audio : activeMusicMediaElement();
+        if (!media) return;
+
+        var request = {
+            player: currentExternalPlayer(),
+            launch: MUSIC_PLAY_LAUNCH_TOKEN,
+            queue: radioQueueIdentity(tracks),
+            media: media,
+            waiting: null
+        };
+        request.onIntent = function (event) {
+            if (!request.waiting) return;
+            // A synthetic end can emit a queued seeking event at the same position.
+            if (event.type === 'seeking' && Math.abs(Number(media.currentTime || 0) - request.waiting.time) < 0.5)
+                return;
+            request.waiting = null;
+            request.resumeCancelled = true;
+        };
+        ['play', 'seeking', 'error'].forEach(function (type) {
+            media.addEventListener(type, request.onIntent);
+        });
+        MUSIC_RADIO_STATE.request = request;
         MUSIC_RADIO_STATE.pending = true;
         MUSIC_RADIO_STATE.lastGeneration = generation;
         MUSIC_RADIO_STATE.lastRequestAt = Date.now();
@@ -4601,7 +4723,7 @@
         var exclude = radioExcludeTracks(tracks);
 
         if (!seeds.length) {
-            MUSIC_RADIO_STATE.pending = false;
+            resetRadioAutoplayRequest();
             return;
         }
 
@@ -4610,16 +4732,30 @@
             + '&limit=20';
 
         requestPost(MUSIC.endpoints.radio, payload, function (json) {
-            MUSIC_RADIO_STATE.pending = false;
+            if (MUSIC_RADIO_STATE.request !== request) return;
+            var current = isRadioAutoplayRequestCurrent(request);
+            var resume = current && canResumeRadioAutoplay(request);
+            resetRadioAutoplayRequest();
 
-            if (!json || !json.available || !Array.isArray(json.tracks) || !json.tracks.length)
+            if (!current || !json || !json.available || !Array.isArray(json.tracks) || !json.tracks.length)
                 return;
 
+            var firstAdded = queueTracks().length;
             var added = appendRadioTracksToManagedQueue(json.tracks);
-            if (added > 0)
+            if (added > 0) {
                 Lampa.Noty.show('Радио добавило треки в очередь.');
+                if (resume) {
+                    if (shouldUseStandaloneIosAudio()) {
+                        var nextIndex = standaloneIosNeighborIndex(1);
+                        if (nextIndex >= 0) standaloneIosPlayIndex(nextIndex);
+                    } else {
+                        scheduleTrackPlayed(queueTracks()[firstAdded]);
+                        playEmbeddedQueueIndexInPlace(firstAdded, 'radio-resume');
+                    }
+                }
+            }
         }, function () {
-            MUSIC_RADIO_STATE.pending = false;
+            if (MUSIC_RADIO_STATE.request === request) resetRadioAutoplayRequest();
         });
     }
 
@@ -5553,6 +5689,7 @@
         }
 
         var nextIndex = standaloneIosNeighborIndex(1);
+        if (nextIndex < 0) waitForRadioAutoplay(MUSIC_IOS_AUDIO.audio);
         return nextIndex >= 0 && standaloneIosPlayIndex(nextIndex);
     }
 
@@ -5741,7 +5878,7 @@
         }
 
         if (action === 'stop') {
-            closeStandaloneIosFullPlayer();
+            if (MUSIC_IOS_FULL_PLAYER_OPEN) closeStandaloneIosFullPlayer();
             stopStandaloneIosAudioPlayback();
             return;
         }
@@ -5800,6 +5937,7 @@
         }
 
         if (action === 'playpause') {
+            cancelRadioAutoplayResume();
             if (audio.paused) {
                 traceStandaloneIosAudio('bar-play', '', true);
                 startStandaloneIosKeepAlive('bar-play');
@@ -5822,6 +5960,94 @@
 
     // --- открытие/закрытие фулл-плеера, back-навигация ---
 
+    function refreshStandaloneIosFullFocus() {
+        var player = MUSIC_IOS_FULL_PLAYER;
+        if (!MUSIC_IOS_FULL_PLAYER_OPEN || !player || !player.length) return;
+        if (safeControllerName() !== 'lampac_music_full_player') return;
+
+        var sheetOpen = player.hasClass('lm-ios-full-player--sheet-open');
+        var root = player.find(sheetOpen ? '.lm-ios-full-player__sheet-panel' : '.lm-ios-full-player__shell').get(0);
+        if (!root) return;
+
+        var target = player.data(sheetOpen ? 'sheetFocus' : 'mainFocus');
+        if (!target || !root.contains(target) || !$(target).hasClass('selector') || $(target).hasClass('disabled')) {
+            target = sheetOpen
+                ? $(root).find('.lm-ios-full-player__queue-item--current, .lm-ios-full-player__sheet-row.selector:not(.disabled), .lm-ios-full-player__lyrics-offset .selector').first().get(0)
+                    || $(root).find('[data-action="sheet-close"]').get(0)
+                : $(root).find('[data-action="playpause"]').get(0);
+        }
+
+        Lampa.Controller.collectionSet(root, false, true);
+        Lampa.Controller.collectionFocus(target || false, root);
+    }
+
+    function scheduleStandaloneIosFullFocus() {
+        var player = MUSIC_IOS_FULL_PLAYER;
+        if (!MUSIC_IOS_FULL_PLAYER_OPEN || !player || player.data('focusRefreshTimer')) return;
+
+        // Batch row creation; never rebuild the focus collection on timeupdate.
+        player.data('focusRefreshTimer', setTimeout(function () {
+            player.removeData('focusRefreshTimer');
+            refreshStandaloneIosFullFocus();
+        }, 0));
+    }
+
+    function moveStandaloneIosFullFocus(direction) {
+        var player = MUSIC_IOS_FULL_PLAYER;
+        if (!player || !MUSIC_IOS_FULL_PLAYER_OPEN) return;
+
+        var sheetOpen = player.hasClass('lm-ios-full-player--sheet-open');
+        var target = player.data(sheetOpen ? 'sheetFocus' : 'mainFocus');
+        if (target && $(target).hasClass('lm-ios-full-player__seek') && (direction === 'left' || direction === 'right')) {
+            stepStandaloneIosSeek(target, direction);
+            return;
+        }
+
+        if (target && $(target).hasClass('lm-ios-full-player__lyrics--plain') && (direction === 'up' || direction === 'down')) {
+            var body = player.find('.lm-ios-full-player__sheet-body').get(0);
+            var before = body.scrollTop;
+            body.scrollTop += (direction === 'down' ? 1 : -1) * body.clientHeight * 0.6;
+            if (body.scrollTop !== before) return;
+        }
+
+        Navigator.move(direction);
+    }
+
+    function backStandaloneIosFullPlayer() {
+        var player = MUSIC_IOS_FULL_PLAYER;
+        if (!MUSIC_IOS_FULL_PLAYER_OPEN || !player) return;
+
+        if (player.hasClass('lm-ios-full-player--sheet-open')) {
+            if (player.attr('data-sheet-kind') === 'queue-item') openStandaloneIosQueueSheet();
+            else closeStandaloneIosSheet();
+        } else closeStandaloneIosFullPlayer();
+    }
+
+    function acceptStandaloneIosControlEvent(event, target) {
+        event.preventDefault();
+        event.stopPropagation();
+        if ($(target).hasClass('disabled')) return false;
+
+        var full = $(target).closest('.lm-ios-full-player');
+        if (full.length) {
+            var sheetOpen = full.hasClass('lm-ios-full-player--sheet-open');
+            var inSheet = $(target).closest('.lm-ios-full-player__sheet-panel').length > 0;
+            if (!MUSIC_IOS_FULL_PLAYER_OPEN || sheetOpen !== inSheet) return false;
+            full.data(inSheet ? 'sheetFocus' : 'mainFocus', target);
+        } else {
+            var bar = $(target).closest('.lm-ios-player');
+            if (MUSIC_IOS_FULL_PLAYER_OPEN || !bar.hasClass('lm-ios-player--visible')) return false;
+            bar.data('focusTarget', target);
+        }
+
+        var previous = $(target).data('musicControlEvent');
+        var now = Date.now();
+        // Lampa emits hover:enter shortly after a native click on a selector.
+        if (previous && previous.type !== event.type && now - previous.at < 300) return false;
+        $(target).data('musicControlEvent', { type: event.type, at: now });
+        return true;
+    }
+
     function openStandaloneIosFullPlayer() {
         var player = ensureStandaloneIosFullPlayer();
 
@@ -5840,10 +6066,12 @@
 
         if (Lampa.Controller && typeof Lampa.Controller.add === 'function') {
             Lampa.Controller.add('lampac_music_full_player', {
-                toggle: function () {},
-                back: function () {
-                    closeStandaloneIosFullPlayer();
-                }
+                toggle: refreshStandaloneIosFullFocus,
+                left: function () { moveStandaloneIosFullFocus('left'); },
+                right: function () { moveStandaloneIosFullFocus('right'); },
+                up: function () { moveStandaloneIosFullFocus('up'); },
+                down: function () { moveStandaloneIosFullFocus('down'); },
+                back: backStandaloneIosFullPlayer
             });
             Lampa.Controller.toggle('lampac_music_full_player');
         }
@@ -5855,6 +6083,8 @@
         MUSIC_IOS_FULL_PLAYER_OPEN = false;
 
         if (MUSIC_IOS_FULL_PLAYER && MUSIC_IOS_FULL_PLAYER.length) {
+            clearTimeout(MUSIC_IOS_FULL_PLAYER.data('focusRefreshTimer'));
+            MUSIC_IOS_FULL_PLAYER.removeData('focusRefreshTimer');
             MUSIC_IOS_FULL_PLAYER.removeClass('lm-ios-full-player--visible');
             MUSIC_IOS_FULL_PLAYER.removeAttr('data-seeking');
             MUSIC_IOS_FULL_PLAYER.removeAttr('data-scroll-current');
@@ -5867,8 +6097,11 @@
             var controller = MUSIC_IOS_FULL_PLAYER_RETURN_CONTROLLER || 'content';
 
             MUSIC_IOS_FULL_PLAYER_RETURN_CONTROLLER = 'content';
+            if (controller === 'lampac_music_player_bar' && !standaloneIosPlayerState().active)
+                controller = MUSIC_IOS_BAR.data('returnController') || 'content';
             if (controller !== 'lampac_music_full_player') Lampa.Controller.toggle(controller);
         }
+        flushStandaloneIosDeferredHomeRefresh();
     }
 
     function currentStandaloneIosControllerName() {
@@ -5886,6 +6119,7 @@
 
     function handleStandaloneIosFullPlayerBack(event) {
         if (!MUSIC_IOS_FULL_PLAYER_OPEN) return;
+        if (safeControllerName() !== 'lampac_music_full_player') return;
 
         var key = event && (event.key || event.code || '');
         var code = event && (event.keyCode || event.which || 0);
@@ -5901,7 +6135,8 @@
 
         event.preventDefault();
         event.stopPropagation();
-        closeStandaloneIosFullPlayer();
+        event.stopImmediatePropagation();
+        if (!event.repeat) backStandaloneIosFullPlayer();
     }
 
     // --- нативные свайпы: закрытие плеера и шита жестом ---
@@ -6247,6 +6482,8 @@
         MUSIC_IOS_FULL_PLAYER.removeAttr('data-queue-key');
         MUSIC_IOS_FULL_PLAYER.removeAttr('data-current-index');
         MUSIC_IOS_FULL_PLAYER.removeAttr('data-scroll-current');
+        MUSIC_IOS_FULL_PLAYER.removeData('sheetFocus');
+        refreshStandaloneIosFullFocus();
     }
 
     function showStandaloneIosSheet(title) {
@@ -6257,9 +6494,12 @@
         player.find('.lm-ios-full-player__sheet-title').text(title || '');
         body.removeClass('lm-ios-full-player__sheet-body--queue').empty();
         player.removeAttr('data-sheet-kind');
+        player.removeAttr('data-sheet-track-id');
+        player.removeData('sheetFocus');
         player.addClass('lm-ios-full-player--sheet-open');
         bumpMusicHeatMetric('fullPlayerSheetOpen');
         logStandaloneIosFullEvent('sheet-open', title || '');
+        scheduleStandaloneIosFullFocus();
         return body;
     }
 
@@ -6288,15 +6528,16 @@
         if (options.trailing) row.append(trailing);
 
         if (options.onSelect) {
-            row.on('click', function (event) {
-                event.preventDefault();
-                event.stopPropagation();
-                if (row.hasClass('disabled')) return;
+            if (!options.disabled) row.addClass('selector').attr('data-controller', 'lampac_music_full_player');
+            row.on('click hover:enter', function (event) {
+                if (!acceptStandaloneIosControlEvent(event, this)) return;
                 options.onSelect(row);
             });
         }
 
         body.append(row);
+        bindStandaloneIosFullControls(MUSIC_IOS_FULL_PLAYER, row.filter('.selector'));
+        scheduleStandaloneIosFullFocus();
         return row;
     }
 
@@ -6849,7 +7090,7 @@
                 updateLyricsOffsetValue(player);
 
                 json.lines.forEach(function (line, index) {
-                    var row = $('<div class="lm-ios-full-player__lyrics-line"></div>');
+                    var row = $('<div class="lm-ios-full-player__lyrics-line selector" data-controller="lampac_music_full_player"></div>');
 
                     row.attr('data-line', index);
                     row.attr('data-time', line.time_ms || 0);
@@ -6864,10 +7105,12 @@
                 player.data('lyricsLineMeta', buildLyricsLineMeta(body, '.lm-ios-full-player__lyrics-line'));
                 updateStandaloneIosLyricsHighlight(true);
             } else {
-                var plain = $('<div class="lm-ios-full-player__lyrics lm-ios-full-player__lyrics--plain"></div>');
+                var plain = $('<div class="lm-ios-full-player__lyrics lm-ios-full-player__lyrics--plain selector" data-controller="lampac_music_full_player"></div>');
                 plain.text(json.plain || json.lines.map(function (line) { return line.text || ''; }).join('\n'));
                 body.append(plain);
             }
+            bindStandaloneIosFullControls(player, body.find('.selector'));
+            scheduleStandaloneIosFullFocus();
         };
 
         if (MUSIC_LYRICS_CACHE[trackId]) {
@@ -6986,6 +7229,7 @@
         if (!MUSIC_IOS_SLEEP_TIMER.endAt) return false;
         if (!force && Date.now() < MUSIC_IOS_SLEEP_TIMER.endAt) return false;
 
+        cancelRadioAutoplayResume();
         if (MUSIC_IOS_SLEEP_TIMER.timer) {
             clearTimeout(MUSIC_IOS_SLEEP_TIMER.timer);
             MUSIC_IOS_SLEEP_TIMER.timer = 0;
@@ -7126,13 +7370,55 @@
             + '</div>'
         );
 
-        player.on('click', '[data-action]', function (event) {
-            event.preventDefault();
-            event.stopPropagation();
+        player.find('[data-action], .lm-ios-full-player__seek').addClass('selector').attr('data-controller', 'lampac_music_full_player');
+        bindStandaloneIosFullControls(player, player.find('.selector'));
+
+        player.on('click', '.lm-ios-full-player__sheet', function (event) {
+            if (event.target === this) closeStandaloneIosSheet();
+        });
+
+        player.on('touchstart', '.lm-ios-full-player__lyrics', function () {
+            player.attr('data-lyrics-manual', String(Date.now()));
+        });
+
+        bindStandaloneIosFullPlayerGestures(player);
+
+        // Capture Back once, before Lampa also dispatches it to the active controller.
+        document.addEventListener('keydown', handleStandaloneIosFullPlayerBack, true);
+
+        $('body').append(player);
+        MUSIC_IOS_FULL_PLAYER = player;
+        return MUSIC_IOS_FULL_PLAYER;
+    }
+
+    function bindStandaloneIosFullControls(player, controls) {
+        // Lampa's hover events do not bubble: bind to each control, including new sheet rows.
+        controls = controls.filter(function () {
+            if ($(this).data('musicControlsBound')) return false;
+            $(this).data('musicControlsBound', true);
+            return true;
+        });
+
+        controls.on('hover:focus hover:hover', function () {
+            var inSheet = $(this).closest('.lm-ios-full-player__sheet-panel').length > 0;
+            player.data(inSheet ? 'sheetFocus' : 'mainFocus', this);
+            if ($(this).hasClass('lm-ios-full-player__lyrics-line'))
+                player.attr('data-lyrics-manual', String(Date.now()));
+            if (inSheet && typeof this.scrollIntoView === 'function')
+                this.scrollIntoView({ block: 'nearest' });
+        });
+
+        controls.filter('.lm-ios-full-player__seek').on('keydown', function (event) {
+            if (safeControllerName() === 'lampac_music_full_player' && (event.keyCode === 37 || event.keyCode === 39))
+                event.preventDefault();
+        });
+
+        controls.filter('[data-action]').on('click hover:enter', function (event) {
+            if (!acceptStandaloneIosControlEvent(event, this)) return;
             handleStandaloneIosPlayerAction($(this).attr('data-action'));
         });
 
-        player.on('input', '.lm-ios-full-player__seek', function () {
+        controls.filter('.lm-ios-full-player__seek').on('input', function () {
             var state = standaloneIosPlayerState();
             var value = Number($(this).val() || 0);
             var position = state.duration ? (state.duration * value / 1000) : 0;
@@ -7142,14 +7428,14 @@
             player.find('.lm-ios-full-player__time--current').text(Lampa.Utils.secondsToTime(position));
         });
 
-        player.on('change', '.lm-ios-full-player__seek', function () {
+        controls.filter('.lm-ios-full-player__seek').on('change', function () {
             player.removeAttr('data-seeking');
             seekStandaloneIosByRangeValue($(this).val());
         });
 
         // лонг-тап по треку очереди → меню действий (убрать/переставить);
         // touchmove отменяет таймер, чтобы скролл списка не открывал меню
-        var queueItemHold = { timer: 0, fired: false };
+        var queueItemHold = { timer: 0, target: null };
 
         function clearQueueItemHoldTimer() {
             if (queueItemHold.timer) {
@@ -7158,47 +7444,45 @@
             }
         }
 
-        player.on('touchstart', '.lm-ios-full-player__queue-item', function () {
+        controls.filter('.lm-ios-full-player__queue-item').on('touchstart', function () {
             var index = Number($(this).attr('data-index') || 0);
+            var target = this;
 
-            queueItemHold.fired = false;
+            queueItemHold.target = null;
             clearQueueItemHoldTimer();
             queueItemHold.timer = setTimeout(function () {
                 queueItemHold.timer = 0;
-                queueItemHold.fired = true;
+                queueItemHold.target = target;
                 openStandaloneIosQueueItemMenu(index);
             }, 550);
         });
 
-        player.on('touchmove touchend touchcancel', '.lm-ios-full-player__queue-item', function () {
+        controls.filter('.lm-ios-full-player__queue-item').on('touchmove touchend touchcancel', function () {
             clearQueueItemHoldTimer();
         });
 
-        player.on('contextmenu', '.lm-ios-full-player__queue-item', function (event) {
+        controls.filter('.lm-ios-full-player__queue-item').on('contextmenu hover:long', function (event) {
             event.preventDefault();
-            queueItemHold.fired = true;
+            event.stopPropagation();
+            if (queueItemHold.target === this) return;
+            queueItemHold.target = this;
+            clearQueueItemHoldTimer();
             openStandaloneIosQueueItemMenu(Number($(this).attr('data-index') || 0));
         });
 
-        player.on('click', '.lm-ios-full-player__queue-item', function (event) {
-            event.preventDefault();
-            event.stopPropagation();
+        controls.filter('.lm-ios-full-player__queue-item').on('click hover:enter', function (event) {
+            if (!acceptStandaloneIosControlEvent(event, this)) return;
 
-            if (queueItemHold.fired) {
-                queueItemHold.fired = false;
+            if (queueItemHold.target === this) {
+                queueItemHold.target = null;
                 return;
             }
 
             standaloneIosPlayIndex(Number($(this).attr('data-index') || 0));
         });
 
-        player.on('click', '.lm-ios-full-player__sheet', function (event) {
-            if (event.target === this) closeStandaloneIosSheet();
-        });
-
-        player.on('click', '.lm-ios-full-player__lyrics-line', function (event) {
-            event.preventDefault();
-            event.stopPropagation();
+        controls.filter('.lm-ios-full-player__lyrics-line').on('click hover:enter', function (event) {
+            if (!acceptStandaloneIosControlEvent(event, this)) return;
 
             var audio = MUSIC_IOS_AUDIO.audio;
             var time = Number($(this).attr('data-time') || 0) + getLyricsOffsetMs(player);
@@ -7213,31 +7497,18 @@
             updateStandaloneIosLyricsHighlight(true);
         });
 
-        player.on('click hover:enter', '[data-lyrics-offset-delta]', function (event) {
-            event.preventDefault();
-            event.stopPropagation();
+        controls.filter('[data-lyrics-offset-delta]').on('click hover:enter', function (event) {
+            if (!acceptStandaloneIosControlEvent(event, this)) return;
             changeLyricsOffset(player, Number($(this).attr('data-lyrics-offset-delta') || 0));
             updateStandaloneIosLyricsHighlight(true);
         });
 
-        player.on('click hover:enter', '[data-lyrics-offset-reset]', function (event) {
-            event.preventDefault();
-            event.stopPropagation();
+        controls.filter('[data-lyrics-offset-reset]').on('click hover:enter', function (event) {
+            if (!acceptStandaloneIosControlEvent(event, this)) return;
             changeLyricsOffset(player, -getLyricsOffsetMs(player));
             updateStandaloneIosLyricsHighlight(true);
         });
 
-        player.on('touchstart', '.lm-ios-full-player__lyrics', function () {
-            player.attr('data-lyrics-manual', String(Date.now()));
-        });
-
-        bindStandaloneIosFullPlayerGestures(player);
-
-        $(document).on('keydown.lampacMusicFullPlayer', handleStandaloneIosFullPlayerBack);
-
-        $('body').append(player);
-        MUSIC_IOS_FULL_PLAYER = player;
-        return MUSIC_IOS_FULL_PLAYER;
     }
 
     function updateStandaloneIosFullQueue(player, state) {
@@ -7287,7 +7558,7 @@
                     list.append($('<div class="lm-ios-full-player__queue-divider"></div>').text('Дальше автоподборка'));
                 }
 
-                var item = $('<div class="lm-ios-full-player__queue-item"></div>');
+                var item = $('<div class="lm-ios-full-player__queue-item selector" data-controller="lampac_music_full_player"></div>');
                 var imageWrap = $('<div class="lm-ios-full-player__queue-img"></div>');
                 var img = $('<img src="" alt="">');
                 var body = $('<div class="lm-ios-full-player__queue-body"></div>');
@@ -7309,9 +7580,11 @@
                 item.append(time);
                 list.append(item);
             });
+            bindStandaloneIosFullControls(player, list.find('.selector'));
             bumpMusicHeatMetric('fullPlayerQueueRender');
             bumpMusicHeatMetric('fullPlayerQueueRenderItems', tracks.length);
             bumpMusicHeatDuration('fullPlayerQueueRender', renderStartedAt);
+            scheduleStandaloneIosFullFocus();
         }
 
         var durationKey = tracks.map(function (track) {
@@ -7461,6 +7734,45 @@
 
     // --- мини-бар плеера ---
 
+    function stepStandaloneIosSeek(target, direction) {
+        var state = standaloneIosPlayerState();
+        if (!state.duration) return;
+        var value = Math.max(0, Math.min(1000, Number($(target).val() || 0) + (direction === 'right' ? 5000 : -5000) / state.duration));
+        $(target).val(value);
+        seekStandaloneIosByRangeValue(value);
+    }
+
+    function focusStandaloneIosPlayerBar() {
+        var bar = MUSIC_IOS_BAR;
+        if (!bar || !bar.hasClass('lm-ios-player--visible') || MUSIC_IOS_FULL_PLAYER_OPEN) return;
+
+        var current = safeControllerName();
+        if (current !== 'lampac_music_player_bar') {
+            bar.data('returnController', current && current !== 'lampac_music_full_player' ? current : 'content');
+            Lampa.Controller.toggle('lampac_music_player_bar');
+            return;
+        }
+
+        var target = bar.data('focusTarget');
+        if (!target || !bar.get(0).contains(target) || $(target).hasClass('disabled'))
+            target = bar.find('[data-action="expand"]').get(0);
+        Lampa.Controller.collectionSet(bar.get(0));
+        Lampa.Controller.collectionFocus(target, bar.get(0));
+    }
+
+    function leaveStandaloneIosPlayerBar() {
+        if (safeControllerName() !== 'lampac_music_player_bar') return;
+        Lampa.Controller.toggle(MUSIC_IOS_BAR.data('returnController') || 'content');
+        flushStandaloneIosDeferredHomeRefresh();
+    }
+
+    function moveStandaloneIosBarFocus(direction) {
+        var target = MUSIC_IOS_BAR.data('focusTarget');
+        if (target && $(target).hasClass('lm-ios-player__seek') && (direction === 'left' || direction === 'right'))
+            stepStandaloneIosSeek(target, direction);
+        else Navigator.move(direction);
+    }
+
     function ensureStandaloneIosPlayerBar() {
         if (MUSIC_IOS_BAR && MUSIC_IOS_BAR.length) return MUSIC_IOS_BAR;
 
@@ -7489,14 +7801,19 @@
             + '</div>'
         );
 
-        bar.on('click', '[data-action]', function (event) {
-            event.preventDefault();
-            event.stopPropagation();
+        var controls = bar.find('[data-action], .lm-ios-player__seek');
+        controls.addClass('selector').attr('data-controller', 'lampac_music_player_bar');
+        controls.on('hover:focus hover:hover', function () {
+            bar.data('focusTarget', this);
+        });
+        controls.filter('[data-action]').on('click hover:enter', function (event) {
+            if (!acceptStandaloneIosControlEvent(event, this)) return;
+            if (Lampa.Platform.screen('tv')) focusStandaloneIosPlayerBar();
             handleStandaloneIosPlayerAction($(this).attr('data-action'));
         });
-
-        bar.on('hover:enter', '[data-action]', function () {
-            handleStandaloneIosPlayerAction($(this).attr('data-action'));
+        controls.filter('.lm-ios-player__seek').on('keydown', function (event) {
+            if (safeControllerName() === 'lampac_music_player_bar' && (event.keyCode === 37 || event.keyCode === 39))
+                event.preventDefault();
         });
 
         bar.on('input', '.lm-ios-player__seek', function () {
@@ -7515,6 +7832,14 @@
 
         $('body').append(bar);
         MUSIC_IOS_BAR = bar;
+        Lampa.Controller.add('lampac_music_player_bar', {
+            toggle: focusStandaloneIosPlayerBar,
+            left: function () { moveStandaloneIosBarFocus('left'); },
+            right: function () { moveStandaloneIosBarFocus('right'); },
+            up: function () { moveStandaloneIosBarFocus('up'); },
+            down: function () { moveStandaloneIosBarFocus('down'); },
+            back: leaveStandaloneIosPlayerBar
+        });
         return MUSIC_IOS_BAR;
     }
 
@@ -7533,6 +7858,10 @@
             MUSIC_IOS_AUDIO.fullPlaybackKey = '';
             MUSIC_IOS_AUDIO.fullProgressKey = '';
             bar.removeClass('lm-ios-player--visible');
+            if (!MUSIC_IOS_AUDIO.active) {
+                MUSIC_IOS_AUDIO.barFocusRequested = false;
+                leaveStandaloneIosPlayerBar();
+            }
             updateStandaloneIosFullPlayer();
             return;
         }
@@ -7574,6 +7903,10 @@
         }
 
         bar.addClass('lm-ios-player--visible');
+        if (MUSIC_IOS_AUDIO.barFocusRequested) {
+            MUSIC_IOS_AUDIO.barFocusRequested = false;
+            focusStandaloneIosPlayerBar();
+        }
         updateStandaloneIosFullPlayer();
     }
 
@@ -7876,6 +8209,7 @@
                 }
             });
             setMediaSessionHandler('pause', function () {
+                cancelRadioAutoplayResume();
                 var media = standaloneIosAudioElement();
                 if (!media) return;
 
@@ -7952,6 +8286,7 @@
     // --- запуск/остановка standalone-воспроизведения, смена трека ---
 
     function stopStandaloneIosAudioPlayback() {
+        resetRadioAutoplayRequest();
         clearStandaloneIosSleepTimer(false);
 
         if (MUSIC_IOS_AUDIO.audio) {
@@ -8028,6 +8363,7 @@
         if (!audio || !playback || !playback.url || !track) return false;
         if (MUSIC_IOS_AUDIO.switching) return false;
 
+        cancelRadioAutoplayResume();
         MUSIC_IOS_AUDIO.switching = true;
         MUSIC_IOS_AUDIO.playing = false;
         MUSIC_IOS_AUDIO.playWatchToken++;
@@ -8114,6 +8450,7 @@
         MUSIC_IOS_AUDIO.prepareToken = (MUSIC_IOS_AUDIO.prepareToken || 0) + 1;
         MUSIC_IOS_AUDIO.shuffleOrder = null;
         MUSIC_IOS_AUDIO.resumePosition = Math.max(0, Number(resumePosition || 0));
+        MUSIC_IOS_AUDIO.barFocusRequested = Lampa.Platform.screen('tv') && !MUSIC_IOS_FULL_PLAYER_OPEN;
         updateStandaloneIosPlayerBar();
         startStandaloneIosKeepAlive('playlist-start');
 
@@ -8617,6 +8954,11 @@
 
         if (!track) return false;
 
+        cancelRadioAutoplayResume();
+        if (origin === 'radio-resume' && musicPlayerPanelEndedCleanup) {
+            clearTimeout(musicPlayerPanelEndedCleanup);
+            musicPlayerPanelEndedCleanup = 0;
+        }
         MUSIC_EMBEDDED_IOS.navigationIndex = index;
 
         // Lampa вычисляет позицию PlayerPlaylist по current URL. Отмечаем
@@ -8650,6 +8992,8 @@
             if (!switchEmbeddedMediaSource(media, playback.url))
                 return;
 
+            // The normal end cleanup may have detached the panel while radio was loading.
+            if (origin === 'radio-resume') startMusicPlayerPanelFix(playback);
             startStandaloneIosKeepAlive('embedded-inplace');
             syncMusicMediaSession(playback);
             updateMediaSessionPositionState();
@@ -8734,6 +9078,7 @@
     }
 
     function pauseEmbeddedMusicMedia(origin) {
+        cancelRadioAutoplayResume();
         var media = activeMusicMediaElement();
         if (!media) return;
 
@@ -8955,6 +9300,7 @@
 
         setMediaSessionHandler('pause', function () {
             var currentData = activePlayerData() || data;
+            cancelRadioAutoplayResume();
             var media = activeMusicMediaElement();
 
             if (shouldUseEmbeddedIosLockscreenSupport(currentData)) {
@@ -9230,7 +9576,9 @@
     }
 
     function selectFromStandaloneIosQueue(index) {
-        return standaloneIosPlayIndex(index);
+        var selected = standaloneIosPlayIndex(index);
+        if (selected && Lampa.Platform.screen('tv')) focusStandaloneIosPlayerBar();
+        return selected;
     }
 
     function requestPlay(track, done, fail) {
@@ -9268,6 +9616,11 @@
             fail: fail
         }];
 
+        // Холодный YouTube-резолв иногда дольше общего сетевого таймаута
+        // клиента (особенно для Spotify-треков без duration/isrc). Не обрываем
+        // живой серверный запрос на 20-й секунде: lazy URL штатного плеера после
+        // такого обрыва превращался в пустую строку и Lampa показывала ложное
+        // «Видео не найдено или повреждено».
         request(buildPlayUrl(track), function (json) {
             var parsed = parseJson(json);
             var callbacks = PLAY_PREFETCH_PENDING[key] || [];
@@ -9290,7 +9643,7 @@
             callbacks.forEach(function (cb) {
                 if (cb.fail) cb.fail(null);
             });
-        });
+        }, 45000);
     }
 
     function normalizePlayedMs(track, playedMs) {
@@ -9308,6 +9661,18 @@
         return value > 0 ? params + '&played_ms=' + encodeURIComponent(value) : params;
     }
 
+    function buildHistoryRequestParams(track) {
+        var params = buildTrackRequestParams(track);
+        var image = selectSizedImage(track && track.images, 250);
+        if (typeof image !== 'string') return params;
+
+        image = image.trim();
+        if (image.indexOf('//') === 0) image = 'https:' + image;
+        if (!/^https?:\/\//i.test(image) || image.length > 8192) return params;
+
+        return params + '&image=' + encodeURIComponent(image);
+    }
+
     function markTrackPlayed(track, playedMs) {
         if (!track || !track.id) return;
 
@@ -9318,7 +9683,7 @@
         // count_play — только здесь: это честный play-путь (после задержки
         // реального воспроизведения); refreshRecentlyPlayedTrack обновляет
         // payload без прослушивания и счётчик статистики не трогает
-        requestPost(MUSIC.endpoints.markHistory, appendPlayedMsParam(buildTrackRequestParams(track) + '&count_play=true', track, playedMs), function () {
+        requestPost(MUSIC.endpoints.markHistory, appendPlayedMsParam(buildHistoryRequestParams(track) + '&count_play=true', track, playedMs), function () {
             refreshStatsTopAfterPlayedTrack();
         }, function () {});
     }
@@ -9329,7 +9694,7 @@
         var value = normalizePlayedMs(track, playedMs);
         if (value <= 0) return;
 
-        requestPost(MUSIC.endpoints.markHistory, appendPlayedMsParam(buildTrackRequestParams(track), track, value), function () {}, function () {});
+        requestPost(MUSIC.endpoints.markHistory, appendPlayedMsParam(buildHistoryRequestParams(track), track, value), function () {}, function () {});
     }
 
     function refreshRecentlyPlayedTrack(track) {
@@ -9338,7 +9703,7 @@
         touchHomeCacheEntry('recently_played', mapTrackCard(track), RECENT_SECTION_STORAGE_LIMIT);
         updateHomeSectionMetaFromCache('recently_played');
         emitRecentChanged('recently_played', track);
-        requestPost(MUSIC.endpoints.markHistory, buildTrackRequestParams(track), function () {}, function () {});
+        requestPost(MUSIC.endpoints.markHistory, buildHistoryRequestParams(track), function () {}, function () {});
     }
 
     function findQueueTrackById(trackId) {
@@ -9780,9 +10145,15 @@
             var media = activeMusicMediaElement();
 
             if (!data || !data.from_music_cluster || !media || media.ended || media.error) {
+                var request = MUSIC_RADIO_STATE.request;
+                var waiting = isRadioAutoplayRequestCurrent(request) && canResumeRadioAutoplay(request)
+                    ? request.waiting : null;
                 traceEmbeddedIos('panel-cleanup', origin || '', true);
                 stopMusicPlayerPanelFix();
                 syncMusicMediaSession(null);
+                // End cleanup invalidates source switches, but is not a user navigation command.
+                if (waiting && MUSIC_RADIO_STATE.request === request && request.waiting === waiting)
+                    waiting.switchToken = MUSIC_EMBEDDED_IOS.switchToken;
             }
         }, 900);
     }
@@ -10121,6 +10492,7 @@
         if (playEmbeddedQueueOffset(1))
             return true;
 
+        waitForRadioAutoplay(media);
         updateEmbeddedIosPlaybackState();
         return true;
     }
@@ -10576,6 +10948,7 @@
                     traceEmbeddedIos('panel-' + event.type, '', true);
                     clearEmbeddedIosLockscreenSupport(event.type);
                     updateEmbeddedIosPlaybackState();
+                    if (event.type === 'ended') waitForRadioAutoplay(media);
                     scheduleMusicPlayerPanelEndCleanup(event.type);
                     return;
                 }
@@ -10657,6 +11030,7 @@
     });
 
     Lampa.Player.listener.follow('destroy', function () {
+        if (!shouldUseStandaloneIosAudio()) resetRadioAutoplayRequest();
         clearPendingInternalPlaylist();
         clearPendingTrackPlayed();
     });
@@ -10966,6 +11340,7 @@
     }
 
     function playTrack(track, playlistTracks, startIndex, options) {
+        resetRadioAutoplayRequest();
         if (playSpotifyReleaseTrack(track, playlistTracks, startIndex, options)) return;
 
         MUSIC_SPOTIFY_RELEASE_TOKEN++;
@@ -13117,7 +13492,8 @@
             html.addClass('loaded');
         });
         img.on('error', function () {
-            img.attr('src', item.image || IMG_BG);
+            if (img.attr('src') !== IMG_BG)
+                img.attr('src', IMG_BG);
             html.addClass('loaded');
         });
         img.attr('src', item.image || IMG_BG);
@@ -13334,6 +13710,7 @@
 
         instance.start = function () {
             if (Lampa.Activity.active().activity !== instance.activity) return;
+            if (isStandaloneIosPlayerForeground()) return;
 
             Lampa.Controller.add('content', {
                 toggle: function () {
@@ -13454,6 +13831,7 @@
 
         var baseStart = this.start;
         this.start = function () {
+            if (isStandaloneIosPlayerForeground()) return;
             baseStart();
 
             if (homeMode && (recentDirty || MUSIC_DEFERRED_HOME_REFRESH)) {
@@ -13472,7 +13850,7 @@
 
             recentDirty = true;
 
-            if (isLampaPlayerOverlayOpen()) {
+            if (isLampaPlayerOverlayOpen() || isStandaloneIosPlayerForeground()) {
                 traceEmbeddedIos('recent-refresh-deferred', detail.section_key || '', true);
                 return;
             }
@@ -13738,6 +14116,7 @@
 
             requestAnimationFrame(function () {
                 if (destroyed || !homeMode || Lampa.Activity.active().activity !== _this.activity) return;
+                if (isStandaloneIosPlayerForeground()) return;
 
                 var lineIndex = -1;
                 for (var i = 0; i < homeLines.length; i++) {
@@ -13754,6 +14133,7 @@
 
                 function restoreHomeLine() {
                     if (destroyed || !homeMode || Lampa.Activity.active().activity !== _this.activity) return;
+                    if (isStandaloneIosPlayerForeground()) return;
                     openHomeLine(lineIndex);
                 }
 
@@ -14650,6 +15030,11 @@
 
                 loadStatsTopSummary(function (stats) {
                     if (destroyed) return;
+                    if (isStandaloneIosPlayerForeground()) {
+                        MUSIC_DEFERRED_HOME_REFRESH = true;
+                        _this.activity.loader(false);
+                        return;
+                    }
 
                     sections.user_playlists = applySectionKey(buildUserPlaylistCardsWithStats(
                         home && Array.isArray(home.user_playlists) ? home.user_playlists : [],
@@ -14989,6 +15374,7 @@
 
         var baseStart = this.start;
         this.start = function () {
+            if (isStandaloneIosPlayerForeground()) return;
             baseStart();
 
             if (sectionDirty) {
@@ -15004,7 +15390,7 @@
 
             sectionDirty = true;
 
-            if (isLampaPlayerOverlayOpen()) {
+            if (isLampaPlayerOverlayOpen() || isStandaloneIosPlayerForeground()) {
                 traceEmbeddedIos('section-refresh-deferred', detail.section_key || '', true);
                 return;
             }
@@ -15739,7 +16125,9 @@
                 posterImg.css('opacity', 1);
             });
             posterImg.on('error', function () {
-                posterImg.attr('src', img).css('opacity', 1);
+                if (posterImg.attr('src') !== IMG_BG)
+                    posterImg.attr('src', IMG_BG);
+                posterImg.css('opacity', 1);
             });
             posterImg.attr('src', img);
 
@@ -16020,7 +16408,9 @@
                     posterImg.css('opacity', 1);
                 });
                 posterImg.on('error', function () {
-                    posterImg.attr('src', img).css('opacity', 1);
+                    if (posterImg.attr('src') !== IMG_BG)
+                        posterImg.attr('src', IMG_BG);
+                    posterImg.css('opacity', 1);
                 });
                 posterImg.attr('src', img);
 
@@ -16862,6 +17252,7 @@
                 overflow: hidden;\
             }\
             .lm-ios-full-player--visible { display: block; }\
+            .lm-ios-full-player .selector.focus, .lm-ios-player .selector.focus { outline: 2px solid #f5f5f7; outline-offset: 2px; }\
             body.lm-ios-full-player-open .lm-ios-player { display: none !important; }\
             .lm-ios-full-player__backdrop {\
                 position: absolute;\


### PR DESCRIPTION
## Что изменено
- Исправлены управление пультом и удержание фокуса в Music Player.
- Исправлены обновление полок после закрытия плеера и открытие артиста из поиска.
- Улучшены продолжение радио, разнообразие и наполнение персональных миксов.
- Исправлены обработка метаданных Spotify/SoundCloud и отображение обложек.
- Добавлена повторная попытка при временных ошибках MusicBrainz.

## Проверка
Проверено на локальном Lampac, включая Android TV.