### PR TITLE
fix(Music): prevent playback races and protect saved state

### DIFF
--- a/Modules/Music/Controllers/ApiController.cs
+++ b/Modules/Music/Controllers/ApiController.cs
@@ -71,7 +71,7 @@ public class ApiController : BaseController
     {
         string profileId = MusicProfileIdentity.Resolve(requestInfo, Request);
         var result = await MusicCatalogService.GetHomeAsync(profileId, daily_salt ?? 0);
-        MusicImageProxyService.Apply(this, result);
+        result = MusicImageProxyService.Apply(this, result);
         return ContentTo(MusicJson.Serialize(result));
     }
 
@@ -81,8 +81,7 @@ public class ApiController : BaseController
     {
         string profileId = MusicProfileIdentity.Resolve(requestInfo, Request);
         var result = await MusicUserPlaylistService.ListAsync(profileId, HttpContext.RequestAborted);
-        foreach (var playlist in result)
-            MusicImageProxyService.Apply(this, playlist);
+        result = MusicImageProxyService.Apply(this, result);
 
         return ContentTo(MusicJson.Serialize(new { available = true, playlists = result }));
     }
@@ -93,8 +92,7 @@ public class ApiController : BaseController
     {
         string profileId = MusicProfileIdentity.Resolve(requestInfo, Request);
         var tracks = await MusicUserPlaylistService.GetTracksAsync(profileId, id, HttpContext.RequestAborted);
-        foreach (var track in tracks)
-            MusicImageProxyService.Apply(this, track);
+        tracks = MusicImageProxyService.Apply(this, tracks);
 
         return ContentTo(MusicJson.Serialize(new { available = true, playlist_id = id, tracks }));
     }
@@ -124,8 +122,7 @@ public class ApiController : BaseController
     {
         string profileId = MusicProfileIdentity.Resolve(requestInfo, Request);
         var result = await MusicUserPlaylistService.ImportAsync(profileId, url, HttpContext.RequestAborted);
-        foreach (var track in result?.tracks ?? new List<MusicTrack>())
-            MusicImageProxyService.Apply(this, track);
+        result = MusicImageProxyService.Apply(this, result);
 
         return ContentTo(MusicJson.Serialize(result));
     }
@@ -136,8 +133,7 @@ public class ApiController : BaseController
     {
         string profileId = MusicProfileIdentity.Resolve(requestInfo, Request);
         var result = await MusicUserPlaylistService.SyncAsync(profileId, id, HttpContext.RequestAborted);
-        foreach (var track in result?.tracks ?? new List<MusicTrack>())
-            MusicImageProxyService.Apply(this, track);
+        result = MusicImageProxyService.Apply(this, result);
 
         return ContentTo(MusicJson.Serialize(result));
     }
@@ -160,7 +156,7 @@ public class ApiController : BaseController
         bool saved = await MusicUserPlaylistService.AddTrackAsync(profileId, id, parsed, HttpContext.RequestAborted);
         var playlist = saved ? await MusicUserPlaylistService.GetSummaryAsync(profileId, id, HttpContext.RequestAborted) : null;
         if (playlist != null)
-            MusicImageProxyService.Apply(this, playlist);
+            playlist = MusicImageProxyService.Apply(this, playlist);
 
         return ContentTo(MusicJson.Serialize(new { saved, playlist_id = id, playlist }));
     }
@@ -173,7 +169,7 @@ public class ApiController : BaseController
         bool removed = await MusicUserPlaylistService.RemoveTrackAsync(profileId, id, track_id, HttpContext.RequestAborted);
         var playlist = removed ? await MusicUserPlaylistService.GetSummaryAsync(profileId, id, HttpContext.RequestAborted) : null;
         if (playlist != null)
-            MusicImageProxyService.Apply(this, playlist);
+            playlist = MusicImageProxyService.Apply(this, playlist);
 
         return ContentTo(MusicJson.Serialize(new { removed, playlist_id = id, track_id, playlist }));
     }
@@ -186,7 +182,7 @@ public class ApiController : BaseController
         bool moved = await MusicUserPlaylistService.MoveTrackAsync(profileId, id, track_id, position, HttpContext.RequestAborted);
         var playlist = moved ? await MusicUserPlaylistService.GetSummaryAsync(profileId, id, HttpContext.RequestAborted) : null;
         if (playlist != null)
-            MusicImageProxyService.Apply(this, playlist);
+            playlist = MusicImageProxyService.Apply(this, playlist);
 
         return ContentTo(MusicJson.Serialize(new { moved, playlist_id = id, track_id, position, playlist }));
     }
@@ -198,8 +194,7 @@ public class ApiController : BaseController
         string profileId = MusicProfileIdentity.Resolve(requestInfo, Request);
         var result = await MusicDailyMixService.GetMixAsync(profileId, day, salt ?? 0, HttpContext.RequestAborted);
 
-        foreach (var track in result?.tracks ?? new List<MusicTrack>())
-            MusicImageProxyService.Apply(this, track);
+        result = MusicImageProxyService.Apply(this, result);
 
         return ContentTo(MusicJson.Serialize(result));
     }
@@ -210,7 +205,7 @@ public class ApiController : BaseController
     {
         string profileId = MusicProfileIdentity.Resolve(requestInfo, Request);
         var result = await MusicStatsService.GetTopAsync(profileId, limit ?? 30, HttpContext.RequestAborted);
-        MusicImageProxyService.Apply(this, result);
+        result = MusicImageProxyService.Apply(this, result);
 
         return ContentTo(MusicJson.Serialize(result));
     }
@@ -259,8 +254,7 @@ public class ApiController : BaseController
             exclude = parseTracks(exclude, maxExclude)
         }, limit ?? 20, HttpContext.RequestAborted);
 
-        foreach (var track in result?.tracks ?? new List<MusicTrack>())
-            MusicImageProxyService.Apply(this, track);
+        result = MusicImageProxyService.Apply(this, result);
 
         return ContentTo(MusicJson.Serialize(result));
     }
@@ -295,7 +289,7 @@ public class ApiController : BaseController
         if (result == null)
             return ContentTo(MusicJson.Serialize(new { available = false, message = "Section not found." }));
 
-        MusicImageProxyService.Apply(this, result);
+        result = MusicImageProxyService.Apply(this, result);
         return ContentTo(MusicJson.Serialize(result));
     }
 }

--- a/Modules/Music/Controllers/SearchController.cs
+++ b/Modules/Music/Controllers/SearchController.cs
@@ -9,7 +9,7 @@ public class SearchController : BaseController
     async public Task<ActionResult> Search(string q, string provider, bool full = false)
     {
         var result = await MusicCatalogService.SearchAsync(q, provider, full);
-        MusicImageProxyService.Apply(this, result);
+        result = MusicImageProxyService.Apply(this, result);
         return ContentTo(MusicJson.Serialize(result));
     }
 
@@ -21,7 +21,7 @@ public class SearchController : BaseController
         if (result == null)
             return ContentTo(MusicJson.Serialize(new { available = false, message = "Artist not found." }));
 
-        MusicImageProxyService.Apply(this, result);
+        result = MusicImageProxyService.Apply(this, result);
         return ContentTo(MusicJson.Serialize(result));
     }
 
@@ -33,7 +33,7 @@ public class SearchController : BaseController
         if (result == null)
             return ContentTo(MusicJson.Serialize(new { available = false, message = "Artist section not found." }));
 
-        MusicImageProxyService.Apply(this, result);
+        result = MusicImageProxyService.Apply(this, result);
         return ContentTo(MusicJson.Serialize(result));
     }
 
@@ -52,7 +52,7 @@ public class SearchController : BaseController
         };
 
         artist.images = await DiscogsArtistImageService.ResolveImagesAsync(artist, cancellationToken) ?? new List<MusicImage>();
-        MusicImageProxyService.Apply(this, artist);
+        artist = MusicImageProxyService.Apply(this, artist);
 
         return ContentTo(MusicJson.Serialize(new
         {
@@ -70,7 +70,7 @@ public class SearchController : BaseController
         if (result == null)
             return ContentTo(MusicJson.Serialize(new { available = false, message = "Album not found." }));
 
-        MusicImageProxyService.Apply(this, result);
+        result = MusicImageProxyService.Apply(this, result);
         return ContentTo(MusicJson.Serialize(result));
     }
 

--- a/Modules/Music/SQL/MusicContext.cs
+++ b/Modules/Music/SQL/MusicContext.cs
@@ -325,38 +325,37 @@ public class MusicContext : DbContext
 
     static void ValidateOrRecoverDatabase()
     {
-        if (!File.Exists(DatabaseFilePath))
+        if (!DatabaseFileExists(DatabaseFilePath))
             return;
 
         if (IsDatabaseValid(DatabaseFilePath))
             return;
 
-        string corruptPath = Path.Combine(DatabaseDirectoryPath, $"Music.sql.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss}");
+        string corruptPath = Path.Combine(DatabaseDirectoryPath, $"Music.sql.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss}-{Guid.NewGuid():N}");
 
-        try
-        {
-            if (File.Exists(corruptPath))
-                File.Delete(corruptPath);
-
-            File.Move(DatabaseFilePath, corruptPath);
-        }
-        catch
-        {
-            try
-            {
-                File.Copy(DatabaseFilePath, corruptPath, overwrite: true);
-                File.Delete(DatabaseFilePath);
-            }
-            catch
-            {
-            }
-        }
+        // If quarantine fails, stop initialization. Never overwrite the original
+        // or discard its WAL after a failed move.
+        File.Move(DatabaseFilePath, corruptPath);
 
         // сайдкары битой базы нельзя оставлять рядом с восстановленным файлом:
         // SQLite попытается проиграть чужой WAL и испортит свежую копию
-        QuarantineSidecarFiles(corruptPath);
-
-        RestoreLatestValidBackup();
+        try
+        {
+            QuarantineSidecarFiles(corruptPath);
+            RestoreLatestValidBackup();
+        }
+        catch
+        {
+            // Leave the original in place for the next startup attempt if a
+            // sidecar or backup is temporarily inaccessible.
+            foreach (var suffix in new[] { "-wal", "-shm" })
+            {
+                if (DatabaseFileExists(corruptPath + suffix))
+                    File.Move(corruptPath + suffix, DatabaseFilePath + suffix);
+            }
+            File.Move(corruptPath, DatabaseFilePath);
+            throw;
+        }
     }
 
     static void QuarantineSidecarFiles(string corruptPath)
@@ -365,27 +364,8 @@ public class MusicContext : DbContext
         {
             string sidecar = DatabaseFilePath + suffix;
 
-            try
-            {
-                if (!File.Exists(sidecar))
-                    continue;
-
-                string target = corruptPath + suffix;
-                if (File.Exists(target))
-                    File.Delete(target);
-
-                File.Move(sidecar, target);
-            }
-            catch
-            {
-                try
-                {
-                    File.Delete(sidecar);
-                }
-                catch
-                {
-                }
-            }
+            if (DatabaseFileExists(sidecar))
+                File.Move(sidecar, corruptPath + suffix);
         }
     }
 
@@ -400,19 +380,41 @@ public class MusicContext : DbContext
             if (!IsDatabaseValid(backupFile))
                 continue;
 
-            TryDeleteSidecarFiles(DatabaseFilePath);
-            File.Copy(backupFile, DatabaseFilePath, overwrite: true);
+            string restorePath = DatabaseFilePath + ".restore-" + Guid.NewGuid().ToString("N");
+            try
+            {
+                File.Copy(backupFile, restorePath);
+                File.Move(restorePath, DatabaseFilePath);
+            }
+            finally
+            {
+                if (File.Exists(restorePath))
+                    File.Delete(restorePath);
+            }
             return true;
         }
 
         return false;
     }
 
+    static bool DatabaseFileExists(string path)
+    {
+        // File.Exists also returns false on permission/I/O errors. Those must
+        // not be mistaken for a missing database during recovery.
+        try
+        {
+            File.GetAttributes(path);
+            return true;
+        }
+        catch (FileNotFoundException) { return false; }
+        catch (DirectoryNotFoundException) { return false; }
+    }
+
     static bool IsDatabaseValid(string path)
     {
         try
         {
-            if (!File.Exists(path))
+            if (!DatabaseFileExists(path))
                 return false;
 
             var info = new FileInfo(path);
@@ -446,8 +448,11 @@ public class MusicContext : DbContext
 
             return string.Equals(result, "ok", StringComparison.OrdinalIgnoreCase);
         }
-        catch
+        catch (SqliteException ex) when (ex.SqliteErrorCode == 11 || ex.SqliteErrorCode == 26)
         {
+            // SQLITE_CORRUPT / SQLITE_NOTADB are evidence of corruption.
+            // Busy, locked, permission and I/O failures propagate, preserving
+            // the database instead of silently rolling it back to a backup.
             return false;
         }
     }

--- a/Modules/Music/Services/Cache/MusicSourceMatchService.cs
+++ b/Modules/Music/Services/Cache/MusicSourceMatchService.cs
@@ -17,6 +17,20 @@ public static class MusicSourceMatchService
     });
     static readonly MemoryCache missingCache = new(new MemoryCacheOptions());
 
+    // Fixed stripes bound memory use; one track/mode shares a gate across providers
+    // so reset, manual selection and late automatic results are ordered together.
+    static readonly SemaphoreSlim[] stateLocks = Enumerable.Range(0, 64)
+        .Select(_ => new SemaphoreSlim(1, 1)).ToArray();
+
+    static SemaphoreSlim StateLock(string trackId, string playbackMode)
+    {
+        string key = NormalizeTrackId(trackId) + ":" + MusicPlaybackModeService.Normalize(playbackMode);
+        return stateLocks[(int)((uint)key.GetHashCode() % (uint)stateLocks.Length)];
+    }
+
+    static MusicAudioMatch CopyMatch(MusicAudioMatch match)
+        => match == null ? null : MusicJson.Deserialize<MusicAudioMatch>(MusicJson.Serialize(match));
+
     static string ScopeProviderId(string providerId, string playbackMode)
     {
         providerId = providerId?.Trim();
@@ -31,28 +45,38 @@ public static class MusicSourceMatchService
         if (string.IsNullOrWhiteSpace(trackId) || string.IsNullOrWhiteSpace(providerId))
             return null;
 
-        string scopedProviderId = ScopeProviderId(providerId, playbackMode);
-        string cacheKey = BuildCacheKey(trackId, scopedProviderId);
-        if (matchCache.TryGetValue(cacheKey, out MusicAudioMatch cachedMatch))
-            return cachedMatch;
-
-        var dbMatch = await ReadDbMatchAsync(trackId, scopedProviderId, cancellationToken);
-        if (dbMatch != null)
+        var stateLock = StateLock(trackId, playbackMode);
+        await stateLock.WaitAsync(cancellationToken);
+        try
         {
-            SetMatchCache(cacheKey, dbMatch);
-            return dbMatch;
-        }
+            string scopedProviderId = ScopeProviderId(providerId, playbackMode);
+            string cacheKey = BuildCacheKey(trackId, scopedProviderId);
+            if (matchCache.TryGetValue(cacheKey, out MusicAudioMatch cachedMatch))
+                return CopyMatch(cachedMatch);
 
-        var entry = await HybridCache.Get().ReadCacheAsync<MusicAudioMatch>(cacheKey, false, null, textJson: true);
-        if (entry.succes && entry.value != null)
+            var dbMatch = await ReadDbMatchAsync(trackId, scopedProviderId, cancellationToken);
+            if (dbMatch != null)
+            {
+                SetMatchCache(cacheKey, dbMatch);
+                return CopyMatch(dbMatch);
+            }
+
+            var entry = await HybridCache.Get().ReadCacheAsync<MusicAudioMatch>(cacheKey, false, null, textJson: true);
+            if (entry.succes && entry.value != null)
+            {
+                // hybrid — территория авто-подбора: pinned авторитетен только из БД,
+                // иначе legacy-запись воскресит сброшенный пользователем выбор
+                entry.value = CopyMatch(entry.value);
+                entry.value.pinned = false;
+                SetMatchCache(cacheKey, entry.value);
+            }
+
+            return entry.succes ? CopyMatch(entry.value) : null;
+        }
+        finally
         {
-            // hybrid — территория авто-подбора: pinned авторитетен только из БД,
-            // иначе legacy-запись воскресит сброшенный пользователем выбор
-            entry.value.pinned = false;
-            SetMatchCache(cacheKey, entry.value);
+            stateLock.Release();
         }
-
-        return entry.succes ? entry.value : null;
     }
 
     // сброс ручного выбора: убирает pinned-строки трека в данном режиме,
@@ -62,13 +86,22 @@ public static class MusicSourceMatchService
         if (string.IsNullOrWhiteSpace(trackId))
             return false;
 
-        if (!await DeleteDbMatchesAsync(trackId, playbackMode, cancellationToken))
-            return false;
+        var stateLock = StateLock(trackId, playbackMode);
+        await stateLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (!await DeleteDbMatchesAsync(trackId, playbackMode, cancellationToken))
+                return false;
 
-        foreach (var provider in MusicProviderRegistry.AudioProviders)
-            matchCache.Remove(BuildCacheKey(trackId, ScopeProviderId(provider.Id, playbackMode)));
+            foreach (var provider in MusicProviderRegistry.AudioProviders)
+                matchCache.Remove(BuildCacheKey(trackId, ScopeProviderId(provider.Id, playbackMode)));
 
-        return true;
+            return true;
+        }
+        finally
+        {
+            stateLock.Release();
+        }
     }
 
     static async Task<bool> DeleteDbMatchesAsync(string trackId, string playbackMode, CancellationToken cancellationToken)
@@ -119,27 +152,42 @@ public static class MusicSourceMatchService
         if (string.IsNullOrWhiteSpace(trackId) || match == null || string.IsNullOrWhiteSpace(match.provider_id) || string.IsNullOrWhiteSpace(match.id))
             return false;
 
-        string scopedProviderId = ScopeProviderId(match.provider_id, playbackMode);
-        string cacheKey = BuildCacheKey(trackId, scopedProviderId);
-
-        if (match.pinned)
+        var stateLock = StateLock(trackId, playbackMode);
+        await stateLock.WaitAsync(cancellationToken);
+        try
         {
-            // ручной выбор — durable state; memory обновляем только после
-            // успешной записи, чтобы «Сохранено» клиенту не врало
-            if (!await SaveDbMatchAsync(trackId, scopedProviderId, match, cancellationToken))
-                return false;
-        }
-        else
-        {
-            // авто-матч — volatile cache: SQLite не трогаем (правило модуля),
-            // in-process свежесть обеспечивает matchCache ниже
-            HybridCache.Get().Set(cacheKey, match, MatchTtl, textJson: true);
-        }
+            match = CopyMatch(match);
+            string scopedProviderId = ScopeProviderId(match.provider_id, playbackMode);
+            string cacheKey = BuildCacheKey(trackId, scopedProviderId);
 
-        SetMatchCache(cacheKey, match);
-        missingCache.Remove(BuildMissingCacheKey(trackId, scopedProviderId));
-        HybridCache.Get().Set(BuildMissingCacheKey(trackId, scopedProviderId), false, MissingTtl, textJson: true);
-        return true;
+            if (match.pinned)
+            {
+                // ручной выбор — durable state; memory обновляем только после
+                // успешной записи, чтобы «Сохранено» клиенту не врало
+                if (!await SaveDbMatchAsync(trackId, scopedProviderId, match, cancellationToken))
+                    return false;
+            }
+            else
+            {
+                // авто-матч — volatile cache: SQLite не трогаем (правило модуля),
+                // in-process свежесть обеспечивает matchCache ниже
+                HybridCache.Get().Set(cacheKey, match, MatchTtl, textJson: true);
+                // A resolver may have started before the user pinned a source.
+                // Keep the automatic result volatile, but never replace that choice.
+                var pinned = await ReadDbMatchAsync(trackId, scopedProviderId, cancellationToken);
+                if (pinned != null)
+                    match = pinned;
+            }
+
+            SetMatchCache(cacheKey, match);
+            missingCache.Remove(BuildMissingCacheKey(trackId, scopedProviderId));
+            HybridCache.Get().Set(BuildMissingCacheKey(trackId, scopedProviderId), false, MissingTtl, textJson: true);
+            return true;
+        }
+        finally
+        {
+            stateLock.Release();
+        }
     }
 
     public static async Task<bool> IsMarkedMissingAsync(string trackId, string providerId, string playbackMode = null, CancellationToken cancellationToken = default)

--- a/Modules/Music/Services/Images/MusicImageProxyService.cs
+++ b/Modules/Music/Services/Images/MusicImageProxyService.cs
@@ -10,7 +10,43 @@ public static class MusicImageProxyService
         plugin = "Music"
     };
 
-    public static MusicSearchResponse Apply(BaseController controller, MusicSearchResponse response)
+    // Cached DTOs (including nested images) can be shared by concurrent requests.
+    // Rewrite only a response-owned copy, never the provider/cache object graph.
+    public static T Apply<T>(BaseController controller, T response)
+    {
+        if (controller == null || response == null)
+            return response;
+
+        var copy = MusicJson.Deserialize<T>(MusicJson.Serialize(response));
+        ApplyImages(controller, (object)copy);
+        return copy;
+    }
+
+    static void ApplyImages(BaseController controller, object response)
+    {
+        switch (response)
+        {
+            case MusicSearchResponse search: ApplyImages(controller, search); break;
+            case MusicHomeResponse home: ApplyImages(controller, home); break;
+            case MusicStatsTopResult stats: ApplyImages(controller, stats); break;
+            case MusicArtist artist: ApplyImages(controller, artist); break;
+            case MusicAlbum album: ApplyImages(controller, album); break;
+            case MusicTrack track: ApplyImages(controller, track); break;
+            case MusicBrowseSection section: ApplyImages(controller, section); break;
+            case MusicUserPlaylistSummary playlist: ApplyImages(controller, playlist); break;
+            case MusicUserPlaylistImportResult import: ApplyImages(controller, import.tracks); break;
+            case MusicDailyMixResponse daily: ApplyImages(controller, daily.tracks); break;
+            case MusicRadioResponse radio: ApplyImages(controller, radio.tracks); break;
+            case IEnumerable<MusicTrack> tracks:
+                foreach (var item in tracks) ApplyImages(controller, item);
+                break;
+            case IEnumerable<MusicUserPlaylistSummary> playlists:
+                foreach (var item in playlists) ApplyImages(controller, item);
+                break;
+        }
+    }
+
+    static MusicSearchResponse ApplyImages(BaseController controller, MusicSearchResponse response)
     {
         if (controller == null || response == null)
             return response;
@@ -18,31 +54,31 @@ public static class MusicImageProxyService
         if (response.artists != null)
         {
             foreach (var artist in response.artists)
-                Apply(controller, artist);
+                ApplyImages(controller, artist);
         }
 
         if (response.albums != null)
         {
             foreach (var album in response.albums)
-                Apply(controller, album);
+                ApplyImages(controller, album);
         }
 
         if (response.tracks != null)
         {
             foreach (var track in response.tracks)
-                Apply(controller, track);
+                ApplyImages(controller, track);
         }
 
         if (response.search_sections != null)
         {
             foreach (var section in response.search_sections)
-                Apply(controller, section);
+                ApplyImages(controller, section);
         }
 
         return response;
     }
 
-    public static MusicHomeResponse Apply(BaseController controller, MusicHomeResponse response)
+    static MusicHomeResponse ApplyImages(BaseController controller, MusicHomeResponse response)
     {
         if (controller == null || response == null)
             return response;
@@ -50,7 +86,7 @@ public static class MusicImageProxyService
         if (response.browse_sections != null)
         {
             foreach (var section in response.browse_sections)
-                Apply(controller, section);
+                ApplyImages(controller, section);
         }
 
         if (response.recently_played != null)
@@ -58,20 +94,20 @@ public static class MusicImageProxyService
             foreach (var item in response.recently_played)
             {
                 if (item?.track != null)
-                    Apply(controller, item.track);
+                    ApplyImages(controller, item.track);
             }
         }
 
         if (response.user_playlists != null)
         {
             foreach (var playlist in response.user_playlists)
-                Apply(controller, playlist);
+                ApplyImages(controller, playlist);
         }
 
         return response;
     }
 
-    public static MusicUserPlaylistSummary Apply(BaseController controller, MusicUserPlaylistSummary playlist)
+    static MusicUserPlaylistSummary ApplyImages(BaseController controller, MusicUserPlaylistSummary playlist)
     {
         if (controller == null || playlist == null)
             return playlist;
@@ -80,7 +116,7 @@ public static class MusicImageProxyService
         return playlist;
     }
 
-    public static MusicStatsTopResult Apply(BaseController controller, MusicStatsTopResult response)
+    static MusicStatsTopResult ApplyImages(BaseController controller, MusicStatsTopResult response)
     {
         if (controller == null || response == null)
             return response;
@@ -90,14 +126,14 @@ public static class MusicImageProxyService
             foreach (var item in response.tracks)
             {
                 if (item?.track != null)
-                    Apply(controller, item.track);
+                    ApplyImages(controller, item.track);
             }
         }
 
         return response;
     }
 
-    public static MusicArtist Apply(BaseController controller, MusicArtist artist)
+    static MusicArtist ApplyImages(BaseController controller, MusicArtist artist)
     {
         if (controller == null || artist == null)
             return artist;
@@ -107,19 +143,19 @@ public static class MusicImageProxyService
         if (artist.albums != null)
         {
             foreach (var album in artist.albums)
-                Apply(controller, album);
+                ApplyImages(controller, album);
         }
 
         if (artist.sections != null)
         {
             foreach (var section in artist.sections)
-                Apply(controller, section);
+                ApplyImages(controller, section);
         }
 
         return artist;
     }
 
-    public static MusicAlbum Apply(BaseController controller, MusicAlbum album)
+    static MusicAlbum ApplyImages(BaseController controller, MusicAlbum album)
     {
         if (controller == null || album == null)
             return album;
@@ -129,13 +165,13 @@ public static class MusicImageProxyService
         if (album.tracks != null)
         {
             foreach (var track in album.tracks)
-                Apply(controller, track);
+                ApplyImages(controller, track);
         }
 
         return album;
     }
 
-    public static MusicTrack Apply(BaseController controller, MusicTrack track)
+    static MusicTrack ApplyImages(BaseController controller, MusicTrack track)
     {
         if (controller == null || track == null)
             return track;
@@ -144,7 +180,7 @@ public static class MusicImageProxyService
         return track;
     }
 
-    public static MusicBrowseSection Apply(BaseController controller, MusicBrowseSection section)
+    static MusicBrowseSection ApplyImages(BaseController controller, MusicBrowseSection section)
     {
         if (controller == null || section == null)
             return section;
@@ -152,19 +188,19 @@ public static class MusicImageProxyService
         if (section.albums != null)
         {
             foreach (var album in section.albums)
-                Apply(controller, album);
+                ApplyImages(controller, album);
         }
 
         if (section.artists != null)
         {
             foreach (var artist in section.artists)
-                Apply(controller, artist);
+                ApplyImages(controller, artist);
         }
 
         if (section.tracks != null)
         {
             foreach (var track in section.tracks)
-                Apply(controller, track);
+                ApplyImages(controller, track);
         }
 
         return section;
@@ -184,12 +220,7 @@ public static class MusicImageProxyService
             if (image.url.StartsWith("//", StringComparison.Ordinal))
                 image.url = "https:" + image.url;
 
-            // кэши секций/сущностей шарят инстансы между запросами, а Apply
-            // мутирует url на месте — хост ПЕРВОГО запросившего запекался в
-            // кэш навсегда (живой баг: SC-полка с 127.0.0.1 после curl-тестов
-            // с хоста — на телефоне все обложки битые). Уже проксированный
-            // url переписываем на хост текущего запроса: токен proxyimg от
-            // хоста не зависит (проверено живьём)
+            // Also repair legacy cached URLs created before response isolation.
             if (TryRewriteProxyHost(image.url, controller.host, out string rewritten))
             {
                 image.url = rewritten;

--- a/Modules/Music/Services/Playlists/MusicUserPlaylistService.cs
+++ b/Modules/Music/Services/Playlists/MusicUserPlaylistService.cs
@@ -233,12 +233,14 @@ public static class MusicUserPlaylistService
             // sync — слияние, а не зеркало: локальный порядок и ручные правки
             // сохраняются, новые треки источника добавляются В НАЧАЛО
             string currentPayload = await ReadPayloadAsync(connection, profileId, playlistId, cancellationToken);
+            if (currentPayload == null)
+                return false; // Deleted while the source was being fetched.
             var merged = MergeSyncedTracks(ParseTracks(currentPayload), imported.tracks);
 
             imported.tracks = merged;
             imported.track_count = merged.Count;
 
-            return await UpsertPlaylistAsync(connection, profileId, playlistId, imported.title, merged, imported.source, cancellationToken) > 0;
+            return await UpsertPlaylistAsync(connection, profileId, playlistId, imported.title, merged, imported.source, cancellationToken, updateOnly: true) > 0;
         }, cancellationToken);
 
         if (!saved)
@@ -407,10 +409,14 @@ public static class MusicUserPlaylistService
         return await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
-    static async Task<int> UpsertPlaylistAsync(SqliteConnection connection, string profileId, string playlistId, string title, List<MusicTrack> tracks, MusicUserPlaylistSource source, CancellationToken cancellationToken)
+    static async Task<int> UpsertPlaylistAsync(SqliteConnection connection, string profileId, string playlistId, string title, List<MusicTrack> tracks, MusicUserPlaylistSource source, CancellationToken cancellationToken, bool updateOnly = false)
     {
         await using var command = connection.CreateCommand();
-        command.CommandText = """
+        command.CommandText = updateOnly ? """
+            UPDATE user_playlists
+            SET title = $title, payload = $payload, source = $source, updated = $updated
+            WHERE profile_id = $profile_id AND playlist_id = $playlist_id;
+            """ : """
             INSERT INTO user_playlists (profile_id, playlist_id, title, payload, source, updated)
             VALUES ($profile_id, $playlist_id, $title, $payload, $source, $updated)
             ON CONFLICT(profile_id, playlist_id) DO UPDATE SET

--- a/Modules/Music/plugin.js
+++ b/Modules/Music/plugin.js
@@ -2106,12 +2106,19 @@
 
         var matchId = track.id ? String(track.id) : '';
         Object.keys(PLAY_PREFETCH_CACHE).forEach(function (key) {
-            if (matchId && key.indexOf('id=' + encodeURIComponent(matchId)) >= 0)
+            if (matchId && ('&' + key + '&').indexOf('&id=' + encodeURIComponent(matchId) + '&') >= 0)
                 delete PLAY_PREFETCH_CACHE[key];
         });
         Object.keys(PLAY_PREFETCH_PENDING).forEach(function (key) {
-            if (matchId && key.indexOf('id=' + encodeURIComponent(matchId)) >= 0)
+            if (matchId && ('&' + key + '&').indexOf('&id=' + encodeURIComponent(matchId) + '&') >= 0) {
+                var callbacks = PLAY_PREFETCH_PENDING[key];
                 delete PLAY_PREFETCH_PENDING[key];
+                setTimeout(function () {
+                    callbacks.forEach(function (cb) {
+                        if (cb.fail) cb.fail(null);
+                    });
+                }, 0);
+            }
         });
     }
 
@@ -4654,6 +4661,16 @@
     function startRadioFromTrack(track, restoreContext) {
         if (!track || !track.id) return;
 
+        var launchToken = ++MUSIC_PLAY_LAUNCH_TOKEN;
+        MUSIC_SPOTIFY_RELEASE_TOKEN++;
+        var prepareToken = MUSIC_IOS_AUDIO.prepareToken;
+        var player = currentExternalPlayer();
+        function stale() {
+            return launchToken !== MUSIC_PLAY_LAUNCH_TOKEN
+                || prepareToken !== MUSIC_IOS_AUDIO.prepareToken
+                || player !== currentExternalPlayer();
+        }
+
         startMusicPlaybackLoading('Подбираю волну');
 
         var seed = compactRadioTrack(track);
@@ -4662,6 +4679,7 @@
             + '&limit=20';
 
         requestPost(MUSIC.endpoints.radio, payload, function (json) {
+            if (stale()) return;
             stopMusicPlaybackLoading();
 
             var radioTracks = json && json.available && Array.isArray(json.tracks) ? json.tracks : [];
@@ -4677,6 +4695,7 @@
 
             playTrack(track, [track].concat(radioTracks), 0, { forceFresh: true });
         }, function () {
+            if (stale()) return;
             stopMusicPlaybackLoading();
             Lampa.Noty.show('Не удалось подобрать треки.');
             restoreMusicFocusContext(restoreContext);
@@ -8373,10 +8392,14 @@
         updateStandaloneIosPlayerBar();
 
         if (typeof playback.url === 'function') {
+            var resolveToken = MUSIC_IOS_AUDIO.playWatchToken;
+            var prepareToken = MUSIC_IOS_AUDIO.prepareToken;
             syncStandaloneIosMediaSession();
             updateStandaloneIosPositionState();
 
             playback.url(function () {
+                if (resolveToken !== MUSIC_IOS_AUDIO.playWatchToken
+                    || prepareToken !== MUSIC_IOS_AUDIO.prepareToken) return;
                 MUSIC_IOS_AUDIO.switching = false;
 
                 if (!playback.url || typeof playback.url !== 'string') {
@@ -8393,7 +8416,8 @@
                     return;
                 }
 
-                standaloneIosPlayIndex(index);
+                var target = MUSIC_IOS_AUDIO.tracks.indexOf(track);
+                if (target >= 0) standaloneIosPlayIndex(target);
             });
 
             return true;
@@ -9594,7 +9618,8 @@
             // всегда) запускал плеер в одном тике с warmup — ломался скраббер
             if (done) {
                 setTimeout(function () {
-                    done(cached);
+                    if (getCachedPlayResponse(track) === cached) done(cached);
+                    else if (fail) fail(null);
                 }, 0);
             }
             return;
@@ -9611,7 +9636,7 @@
         }
 
         bumpMusicHeatMetric('playNetwork');
-        PLAY_PREFETCH_PENDING[key] = [{
+        var callbacks = PLAY_PREFETCH_PENDING[key] = [{
             done: done,
             fail: fail
         }];
@@ -9622,8 +9647,8 @@
         // такого обрыва превращался в пустую строку и Lampa показывала ложное
         // «Видео не найдено или повреждено».
         request(buildPlayUrl(track), function (json) {
+            if (PLAY_PREFETCH_PENDING[key] !== callbacks) return;
             var parsed = parseJson(json);
-            var callbacks = PLAY_PREFETCH_PENDING[key] || [];
             delete PLAY_PREFETCH_PENDING[key];
 
             if (parsed && parsed.available && parsed.sources && parsed.sources.length) {
@@ -9638,7 +9663,7 @@
                 if (cb.fail) cb.fail(parsed);
             });
         }, function () {
-            var callbacks = PLAY_PREFETCH_PENDING[key] || [];
+            if (PLAY_PREFETCH_PENDING[key] !== callbacks) return;
             delete PLAY_PREFETCH_PENDING[key];
             callbacks.forEach(function (cb) {
                 if (cb.fail) cb.fail(null);
@@ -9987,8 +10012,16 @@
                 var embeddedResolveToken = shouldUseStandaloneIosAudio()
                     ? 0
                     : ++MUSIC_EMBEDDED_IOS.switchToken;
+                var standaloneResolveToken = embeddedResolveToken ? null : MUSIC_IOS_AUDIO.playWatchToken;
+                var standalonePrepareToken = MUSIC_IOS_AUDIO.prepareToken;
+                function standaloneStale() {
+                    return standaloneResolveToken !== null
+                        && (standaloneResolveToken !== MUSIC_IOS_AUDIO.playWatchToken
+                            || standalonePrepareToken !== MUSIC_IOS_AUDIO.prepareToken);
+                }
 
                 requestPlay(track, function (json) {
+                    if (standaloneStale()) return;
                     if (embeddedResolveToken && embeddedResolveToken !== MUSIC_EMBEDDED_IOS.switchToken) {
                         traceEmbeddedIos('playlist-resolve-stale', track && track.id ? track.id : '', true);
                         return;
@@ -10006,6 +10039,7 @@
                     playback.music_duration_ms = track.duration_ms || playback.music_duration_ms;
                     call();
                 }, function (json) {
+                    if (standaloneStale()) return;
                     if (embeddedResolveToken && embeddedResolveToken !== MUSIC_EMBEDDED_IOS.switchToken) {
                         traceEmbeddedIos('playlist-resolve-failed-stale', track && track.id ? track.id : '', true);
                         return;
@@ -10021,6 +10055,7 @@
                     playback.url = '';
 
                     if (!maybeAutoSkipUnavailableTrack(json, function () {
+                        if (standaloneStale()) return;
                         if (embeddedResolveToken && embeddedResolveToken !== MUSIC_EMBEDDED_IOS.switchToken) return;
                         advanceQueueAfterUnavailable(track && track.id, playback);
                     }))
@@ -11206,6 +11241,7 @@
     }
 
     function buildStandaloneIosPreparedPlaylist(tracks, startIndex, currentJson, done, providerId) {
+        tracks = tracks.slice();
         if (!shouldUseStagedStandaloneIosPreparation(providerId)) {
             buildInternalPreparedPlaylist(tracks, startIndex, currentJson, function (preparedList) {
                 done(preparedList, null);
@@ -11284,18 +11320,23 @@
                 }
 
                 var entryIndex = backgroundOrder[pointer++];
+                var currentIndex = (MUSIC_IOS_AUDIO.tracks || []).indexOf(tracks[entryIndex]);
+                var pendingPlayback = currentIndex >= 0 && MUSIC_IOS_AUDIO.playlist[currentIndex];
+                if (!pendingPlayback) {
+                    scheduleWarm(warmDelay);
+                    return;
+                }
                 active = true;
                 bumpMusicHeatMetric('standaloneWarmRequest');
 
                 requestPlay(tracks[entryIndex], function (json) {
                     active = false;
-                    if (stillCurrent() && MUSIC_IOS_AUDIO.playlist && entryIndex < MUSIC_IOS_AUDIO.playlist.length)
-                        MUSIC_IOS_AUDIO.playlist[entryIndex] = buildResolvedPlayback(tracks[entryIndex], json);
+                    var target = stillCurrent() ? MUSIC_IOS_AUDIO.playlist.indexOf(pendingPlayback) : -1;
+                    if (target >= 0)
+                        MUSIC_IOS_AUDIO.playlist[target] = buildResolvedPlayback(tracks[entryIndex], json);
                     scheduleWarm(warmDelay);
                 }, function () {
                     active = false;
-                    if (stillCurrent() && MUSIC_IOS_AUDIO.playlist && entryIndex < MUSIC_IOS_AUDIO.playlist.length)
-                        MUSIC_IOS_AUDIO.playlist[entryIndex] = buildPlayback(tracks[entryIndex]);
                     scheduleWarm(warmDelay);
                 });
             }
@@ -11341,6 +11382,7 @@
 
     function playTrack(track, playlistTracks, startIndex, options) {
         resetRadioAutoplayRequest();
+        var launchToken = ++MUSIC_PLAY_LAUNCH_TOKEN;
         if (playSpotifyReleaseTrack(track, playlistTracks, startIndex, options)) return;
 
         MUSIC_SPOTIFY_RELEASE_TOKEN++;
@@ -11349,7 +11391,6 @@
         var standaloneIos = shouldUseStandaloneIosAudio();
         var forceFresh = !!(options && options.forceFresh);
         var resumePosition = Math.max(0, Number(options && options.resumePosition || 0));
-        var launchToken = ++MUSIC_PLAY_LAUNCH_TOKEN;
         // оверлей предыдущего (только что отменённого) запуска гасим сразу:
         // дальше любой видимый лоадер принадлежит только новейшему флоу
         stopMusicPlaybackLoading();


### PR DESCRIPTION
Исправлены гонки очереди, кэша воспроизведения и радио, сохранение ручного выбора источника, адреса обложек между устройствами, повторное появление удалённых плейлистов и ошибочное восстановление SQLite при временной недоступности базы.
